### PR TITLE
Perform thread_suspend in loop as it may be interrupted.

### DIFF
--- a/darwin_stop_world.c
+++ b/darwin_stop_world.c
@@ -636,7 +636,9 @@ GC_INNER void GC_stop_world(void)
         if ((p->flags & FINISHED) == 0 && !p->thread_blocked &&
              p->stop_info.mach_thread != my_thread) {
 
-          kern_result = thread_suspend(p->stop_info.mach_thread);
+          do {
+            kern_result = thread_suspend(p->stop_info.mach_thread);
+          } while (kern_result == KERN_ABORTED);
           if (kern_result != KERN_SUCCESS)
             ABORT("thread_suspend failed");
           if (GC_on_thread_event)


### PR DESCRIPTION
Case 1062514 - Fix random crash during GC thread suspend on OSX