### PR TITLE
Fix thread_suspend fail for threads registered from key destructor (O…

### DIFF
--- a/pthread_support.c
+++ b/pthread_support.c
@@ -1576,6 +1576,11 @@ GC_API int GC_CALL GC_register_my_thread(const struct GC_stack_base *sb)
     } else if ((me -> flags & FINISHED) != 0) {
         /* This code is executed when a thread is registered from the   */
         /* client thread key destructor.                                */
+#       ifdef GC_DARWIN_THREADS
+          /* Reinitialize mach_thread to avoid thread_suspend fail      */
+          /* with MACH_SEND_INVALID_DEST error.                         */
+          me -> stop_info.mach_thread = mach_thread_self();
+#       endif
         GC_record_stack_base(me, sb);
         me -> flags &= ~FINISHED; /* but not DETACHED */
 #       ifdef GC_EXPLICIT_SIGNALS_UNBLOCK


### PR DESCRIPTION
cherry-pick fix for thread_suspend failure with MACH_SEND_INVALID_DEST error to 2018.2