### PR TITLE
Make sure GC symbols we want to patch are visible

### DIFF
--- a/extra/gc.c
+++ b/extra/gc.c
@@ -30,8 +30,14 @@
 #ifndef __cplusplus
   /* static is desirable here for more efficient linkage.               */
   /* TODO: Enable this in case of the compilation as C++ code.          */
+#if IL2CPP_ENABLE_STRICT_WRITE_BARRIERS
+/* We need all il2cpp symbols to be public when using write barrier     */
+/* validation, so that we can patch them.                               */
+# define GC_API __attribute__((visibility("default")))
+#else
 # define GC_INNER STATIC
 # define GC_EXTERN GC_INNER
+#endif
                 /* STATIC is defined in gcconfig.h. */
 #endif
 

--- a/include/private/gc_priv.h
+++ b/include/private/gc_priv.h
@@ -2181,7 +2181,7 @@ GC_EXTERN GC_bool GC_print_back_height;
 #endif /* !GC_DISABLE_INCREMENTAL */
 
 #ifdef MANUAL_VDB
-  GC_INNER void GC_dirty_inner(const void *p); /* does not require locking */
+  GC_API void GC_dirty_inner(const void *p); /* does not require locking */
 # define GC_dirty(p) (GC_incremental ? GC_dirty_inner(p) : (void)0)
 #else
 # define GC_dirty(p) (void)(p)

--- a/os_dep.c
+++ b/os_dep.c
@@ -3041,7 +3041,7 @@ GC_API GC_push_other_roots_proc GC_CALL GC_get_push_other_roots(void)
 
   /* Mark the page containing p as dirty.  Logically, this dirties the  */
   /* entire object.                                                     */
-  GC_INNER void GC_dirty_inner(const void *p)
+  GC_API void GC_dirty_inner(const void *p)
   {
     word index = PHT_HASH(p);
     async_set_pht_entry_from_index(GC_dirty_pages, index);


### PR DESCRIPTION
In order to do GC write barrier validation, we want to patch some of the GC symbols at runtime to install the tracking variants from the validator. In order to do that, the symbols we want to replace need to be exported.