### PR TITLE
Compile Boehm Without C Runtime

### DIFF
--- a/mach_dep.c
+++ b/mach_dep.c
@@ -298,6 +298,9 @@ GC_INNER void GC_with_callee_saves_pushed(void (*fn)(ptr_t, void *),
         /* force callee-save registers and register windows onto        */
         /* the stack.                                                   */
         __builtin_unwind_init();
+#     elif defined(NO_CRT) && defined(MSWIN32)
+        CONTEXT ctx;
+        RtlCaptureContext(&ctx);
 #     else
         /* Generic code                          */
         /* The idea is due to Parag Patel at HP. */

--- a/mark.c
+++ b/mark.c
@@ -489,13 +489,16 @@ static void alloc_mark_stack(size_t);
       /* It's conceivable that this is the same issue with       */
       /* terminating threads that we see with Linux and          */
       /* USE_PROC_FOR_LIBRARIES.                                 */
-
+#ifndef NO_CRT
       __try {
+#endif
           ret_val = GC_mark_some_inner(cold_gc_frame);
+#ifndef NO_CRT
       } __except (GetExceptionCode() == EXCEPTION_ACCESS_VIOLATION ?
                 EXCEPTION_EXECUTE_HANDLER : EXCEPTION_CONTINUE_SEARCH) {
           goto handle_ex;
       }
+#endif
 #     if defined(GC_WIN32_THREADS) && !defined(GC_PTHREADS)
         /* With DllMain-based thread tracking, a thread may have        */
         /* started while we were marking.  This is logically equivalent */

--- a/win32_threads.c
+++ b/win32_threads.c
@@ -2216,13 +2216,13 @@ GC_INNER void GC_get_next_stack(char *start, char *limit,
     /* Clear the thread entry even if we exit with an exception.        */
     /* This is probably pointless, since an uncaught exception is       */
     /* supposed to result in the process being killed.                  */
-#   ifndef __GNUC__
+#if !defined(__GNUC__) && !defined(NO_CRT)
       __try
 #   endif
     {
       ret = (void *)(word)(*start)(param);
     }
-#   ifndef __GNUC__
+#if !defined(__GNUC__) && !defined(NO_CRT)
       __finally
 #   endif
     {
@@ -2290,7 +2290,7 @@ GC_INNER void GC_get_next_stack(char *start, char *limit,
     ExitThread(dwExitCode);
   }
 
-# if !defined(CYGWIN32) && !defined(MSWINCE) && !defined(MSWIN_XBOX1)
+# if !defined(NO_CRT) && !defined(CYGWIN32) && !defined(MSWINCE) && !defined(MSWIN_XBOX1)
     GC_API GC_uintptr_t GC_CALL GC_beginthreadex(
                                   void *security, unsigned stack_size,
                                   unsigned (__stdcall *start_address)(void *),


### PR DESCRIPTION
Changes needed to compile without the C runtime linked (requires linking with library that stubs a few things we still need such as malloc)