### PR TITLE
Add IL2CPP_ENABLE_WRITE_BARRIER_VALIDATION to remove functions we wan…

### DIFF
--- a/extra/gc.c
+++ b/extra/gc.c
@@ -30,18 +30,8 @@
 #ifndef __cplusplus
   /* static is desirable here for more efficient linkage.               */
   /* TODO: Enable this in case of the compilation as C++ code.          */
-#if IL2CPP_ENABLE_STRICT_WRITE_BARRIERS
-#if defined(__GNUC__)
-# define GC_API __attribute__((visibility("default")))
-# define GC_API_PATCHABLE GC_API __attribute__ ((noinline))
-#else
-# define GC_API __declspec( dllexport )
-# define GC_API_PATCHABLE GC_API __declspec(noinline)
-#endif
-#else
 # define GC_INNER STATIC
 # define GC_EXTERN GC_INNER
-#endif
                 /* STATIC is defined in gcconfig.h. */
 #endif
 

--- a/gcj_mlc.c
+++ b/gcj_mlc.c
@@ -150,6 +150,7 @@ static void maybe_finalize(void)
 /* Allocate an object, clear it, and store the pointer to the   */
 /* type structure (vtable in gcj).                              */
 /* This adds a byte at the end of the object if GC_malloc would.*/
+#if !IL2CPP_ENABLE_WRITE_BARRIER_VALIDATION
 #ifdef THREAD_LOCAL_ALLOC
   GC_INNER void * GC_core_gcj_malloc(size_t lb,
                                      void * ptr_to_struct_containing_descr)
@@ -196,6 +197,7 @@ static void maybe_finalize(void)
     GC_dirty(op);
     return((void *) op);
 }
+#endif
 
 /* Similar to GC_gcj_malloc, but add debug info.  This is allocated     */
 /* with GC_gcj_debug_kind.                                              */

--- a/include/gc_config_macros.h
+++ b/include/gc_config_macros.h
@@ -227,10 +227,6 @@
 # define GC_CALLBACK GC_CALL
 #endif
 
-#ifndef GC_API_PATCHABLE
-# define GC_API_PATCHABLE GC_API
-#endif
-
 #ifndef GC_ATTR_MALLOC
   /* 'malloc' attribute should be used for all malloc-like functions    */
   /* (to tell the compiler that a function may be treated as if any     */

--- a/include/private/gc_priv.h
+++ b/include/private/gc_priv.h
@@ -2181,7 +2181,7 @@ GC_EXTERN GC_bool GC_print_back_height;
 #endif /* !GC_DISABLE_INCREMENTAL */
 
 #ifdef MANUAL_VDB
-  GC_API_PATCHABLE void GC_dirty_inner(const void *p); /* does not require locking */
+  GC_API void GC_dirty_inner(const void *p); /* does not require locking */
 # define GC_dirty(p) (GC_incremental ? GC_dirty_inner(p) : (void)0)
 #else
 # define GC_dirty(p) (void)(p)

--- a/malloc.c
+++ b/malloc.c
@@ -334,6 +334,7 @@ GC_API GC_ATTR_MALLOC void * GC_CALL GC_malloc_kind_global(size_t lb, int k)
   }
 #endif
 
+#if !IL2CPP_ENABLE_WRITE_BARRIER_VALIDATION
 /* Allocate lb bytes of atomic (pointer-free) data.     */
 GC_API GC_ATTR_MALLOC void * GC_CALL GC_malloc_atomic(size_t lb)
 {
@@ -345,6 +346,7 @@ GC_API GC_ATTR_MALLOC void * GC_CALL GC_malloc(size_t lb)
 {
     return GC_malloc_kind(lb, NORMAL);
 }
+#endif
 
 GC_API GC_ATTR_MALLOC void * GC_CALL GC_generic_malloc_uncollectable(
                                                         size_t lb, int k)
@@ -405,11 +407,13 @@ GC_API GC_ATTR_MALLOC void * GC_CALL GC_generic_malloc_uncollectable(
     return op;
 }
 
+#if !IL2CPP_ENABLE_WRITE_BARRIER_VALIDATION
 /* Allocate lb bytes of pointerful, traced, but not collectible data.   */
 GC_API GC_ATTR_MALLOC void * GC_CALL GC_malloc_uncollectable(size_t lb)
 {
   return GC_generic_malloc_uncollectable(lb, UNCOLLECTABLE);
 }
+#endif
 
 #ifdef GC_ATOMIC_UNCOLLECTABLE
   /* Allocate lb bytes of pointer-free, untraced, uncollectible data    */
@@ -553,6 +557,7 @@ GC_API GC_ATTR_MALLOC void * GC_CALL GC_malloc_uncollectable(size_t lb)
 
 #endif /* REDIRECT_MALLOC */
 
+#if !IL2CPP_ENABLE_WRITE_BARRIER_VALIDATION
 /* Explicitly deallocate an object p.                           */
 GC_API void GC_CALL GC_free(void * p)
 {
@@ -618,6 +623,7 @@ GC_API void GC_CALL GC_free(void * p)
         UNLOCK();
     }
 }
+#endif
 
 /* Explicitly deallocate an object p when we already hold lock.         */
 /* Only used for internally allocated objects, so we can take some      */

--- a/os_dep.c
+++ b/os_dep.c
@@ -3041,11 +3041,13 @@ GC_API GC_push_other_roots_proc GC_CALL GC_get_push_other_roots(void)
 
   /* Mark the page containing p as dirty.  Logically, this dirties the  */
   /* entire object.                                                     */
-  GC_API_PATCHABLE void GC_dirty_inner(const void *p)
+#if !IL2CPP_ENABLE_WRITE_BARRIER_VALIDATION
+  GC_API void GC_dirty_inner(const void *p)
   {
     word index = PHT_HASH(p);
     async_set_pht_entry_from_index(GC_dirty_pages, index);
   }
+#endif
 
 # ifdef CHECKSUMS
     /* Could any valid GC heap pointer ever have been written to this page? */


### PR DESCRIPTION
Add IL2CPP_ENABLE_WRITE_BARRIER_VALIDATION to remove functions we want to patch for validation. For il2cpp we can just provide them directly, and then we don't need to patch, which is much simpler. Instead remove the hacks previously added to gc.c to make sure these symbols got exported so we could dynamically load and then patch them at runtime in Unity.