### PR TITLE
Concurrency fixes from upstream

### DIFF
--- a/darwin_stop_world.c
+++ b/darwin_stop_world.c
@@ -536,7 +536,17 @@ STATIC GC_bool GC_suspend_thread_list(thread_act_array_t act_list, int count,
 #   ifdef DEBUG_THREADS
       GC_log_printf("Suspending %p\n", (void *)(word)thread);
 #   endif
+<<<<<<< HEAD
     kern_result = thread_suspend(thread);
+=======
+    /* Unconditionally suspend the thread.  It will do no     */
+    /* harm if it is already suspended by the client logic.   */
+    GC_acquire_dirty_lock();
+    do {
+      kern_result = thread_suspend(thread);
+    } while (kern_result == KERN_ABORTED);
+    GC_release_dirty_lock();
+>>>>>>> 0c0e4cd0... Fix concurrent bitmap update in GC_dirty
     if (kern_result != KERN_SUCCESS) {
       /* The thread may have quit since the thread_threads() call we  */
       /* mark already suspended so it's not dealt with anymore later. */
@@ -635,10 +645,11 @@ GC_INNER void GC_stop_world(void)
       for (p = GC_threads[i]; p != NULL; p = p->next) {
         if ((p->flags & FINISHED) == 0 && !p->thread_blocked &&
              p->stop_info.mach_thread != my_thread) {
-
+          GC_acquire_dirty_lock();
           do {
             kern_result = thread_suspend(p->stop_info.mach_thread);
           } while (kern_result == KERN_ABORTED);
+          GC_release_dirty_lock();
           if (kern_result != KERN_SUCCESS)
             ABORT("thread_suspend failed");
           if (GC_on_thread_event)

--- a/darwin_stop_world.c
+++ b/darwin_stop_world.c
@@ -536,9 +536,6 @@ STATIC GC_bool GC_suspend_thread_list(thread_act_array_t act_list, int count,
 #   ifdef DEBUG_THREADS
       GC_log_printf("Suspending %p\n", (void *)(word)thread);
 #   endif
-<<<<<<< HEAD
-    kern_result = thread_suspend(thread);
-=======
     /* Unconditionally suspend the thread.  It will do no     */
     /* harm if it is already suspended by the client logic.   */
     GC_acquire_dirty_lock();
@@ -546,7 +543,7 @@ STATIC GC_bool GC_suspend_thread_list(thread_act_array_t act_list, int count,
       kern_result = thread_suspend(thread);
     } while (kern_result == KERN_ABORTED);
     GC_release_dirty_lock();
->>>>>>> 0c0e4cd0... Fix concurrent bitmap update in GC_dirty
+
     if (kern_result != KERN_SUCCESS) {
       /* The thread may have quit since the thread_threads() call we  */
       /* mark already suspended so it's not dealt with anymore later. */

--- a/include/private/gc_priv.h
+++ b/include/private/gc_priv.h
@@ -2312,7 +2312,17 @@ GC_EXTERN signed_word GC_bytes_found;
                                 /* protected by GC_write_cs.    */
 
 # endif
-# ifdef MPROTECT_VDB
+# if defined(GC_DISABLE_INCREMENTAL)
+#   define GC_acquire_dirty_lock() (void)0
+#   define GC_release_dirty_lock() (void)0
+# else
+    /* Acquire the spin lock we use to update dirty bits.       */
+    /* Threads should not get stopped holding it.  But we may   */
+    /* acquire and release it during GC_remove_protection call. */
+#   define GC_acquire_dirty_lock() \
+        do { /* empty */ \
+        } while (AO_test_and_set_acquire(&GC_fault_handler_lock) == AO_TS_SET)
+#   define GC_release_dirty_lock() AO_CLEAR(&GC_fault_handler_lock)
     GC_EXTERN volatile AO_TS_t GC_fault_handler_lock;
                                         /* defined in os_dep.c */
 # endif

--- a/include/private/gc_priv.h
+++ b/include/private/gc_priv.h
@@ -952,26 +952,16 @@ typedef word page_hash_table[PHT_SIZE];
 # define get_pht_entry_from_index(bl, index) \
                 (((bl)[divWORDSZ(index)] >> modWORDSZ(index)) & 1)
 # define set_pht_entry_from_index(bl, index) \
-                (bl)[divWORDSZ(index)] |= (word)1 << modWORDSZ(index)
-# define clear_pht_entry_from_index(bl, index) \
-                (bl)[divWORDSZ(index)] &= ~((word)1 << modWORDSZ(index))
-/* And a dumb but thread-safe version of set_pht_entry_from_index.      */
-/* This sets (many) extra bits.                                         */
-# define set_pht_entry_from_index_safe(bl, index) \
-                (bl)[divWORDSZ(index)] = ONES
+                (void)((bl)[divWORDSZ(index)] |= (word)1 << modWORDSZ(index))
 
-/* And, one more version for GC_add_to_black_list_normal/stack.         */
-/* The latter ones are invoked (indirectly) by GC_do_local_mark.        */
-#if defined(PARALLEL_MARK) && defined(THREAD_SANITIZER)
+#if defined(THREADS) && defined(AO_HAVE_or)
+  /* And, one more version for GC_add_to_black_list_normal/stack        */
+  /* (invoked indirectly by GC_do_local_mark) and                       */
+  /* async_set_pht_entry_from_index (invoked by GC_dirty or the write   */
+  /* fault handler).                                                    */
 # define set_pht_entry_from_index_concurrent(bl, index) \
                 AO_or((volatile AO_t *)&(bl)[divWORDSZ(index)], \
                       (AO_t)((word)1 << modWORDSZ(index)))
-#else
-  /* It is safe to set a bit in a blacklist even without        */
-  /* synchronization, the only drawback is that we might have   */
-  /* to redo blacklisting sometimes.                            */
-# define set_pht_entry_from_index_concurrent(bl, index) \
-                set_pht_entry_from_index(bl, index)
 #endif
 
 
@@ -2312,7 +2302,8 @@ GC_EXTERN signed_word GC_bytes_found;
                                 /* protected by GC_write_cs.    */
 
 # endif
-# if defined(GC_DISABLE_INCREMENTAL)
+# if defined(GC_DISABLE_INCREMENTAL) \
+     || defined(set_pht_entry_from_index_concurrent)
 #   define GC_acquire_dirty_lock() (void)0
 #   define GC_release_dirty_lock() (void)0
 # else

--- a/os_dep.c
+++ b/os_dep.c
@@ -3040,13 +3040,15 @@ GC_API GC_push_other_roots_proc GC_CALL GC_get_push_other_roots(void)
 # ifndef THREADS
 #   define async_set_pht_entry_from_index(db, index) \
                         set_pht_entry_from_index(db, index)
+# elif defined(set_pht_entry_from_index_concurrent)
+#   define async_set_pht_entry_from_index(db, index) \
+                        set_pht_entry_from_index_concurrent(db, index)
 # elif defined(AO_HAVE_test_and_set_acquire)
     /* We need to lock around the bitmap update (in the write fault     */
     /* handler or GC_dirty) in order to avoid the risk of losing a bit. */
     /* We do this with a test-and-set spin lock if possible.            */
     GC_INNER volatile AO_TS_t GC_fault_handler_lock = AO_TS_INITIALIZER;
 
-    GC_ATTR_NO_SANITIZE_THREAD
     static void async_set_pht_entry_from_index(volatile page_hash_table db,
                                                size_t index)
     {

--- a/os_dep.c
+++ b/os_dep.c
@@ -3036,8 +3036,28 @@ GC_API GC_push_other_roots_proc GC_CALL GC_get_push_other_roots(void)
     BZERO((word *)GC_dirty_pages, (sizeof GC_dirty_pages));
   }
 
-# define async_set_pht_entry_from_index(db, index) \
-                        set_pht_entry_from_index(db, index) /* for now */
+#ifndef GC_DISABLE_INCREMENTAL
+# ifndef THREADS
+#   define async_set_pht_entry_from_index(db, index) \
+                        set_pht_entry_from_index(db, index)
+# elif defined(AO_HAVE_test_and_set_acquire)
+    /* We need to lock around the bitmap update (in the write fault     */
+    /* handler or GC_dirty) in order to avoid the risk of losing a bit. */
+    /* We do this with a test-and-set spin lock if possible.            */
+    GC_INNER volatile AO_TS_t GC_fault_handler_lock = AO_TS_INITIALIZER;
+
+    GC_ATTR_NO_SANITIZE_THREAD
+    static void async_set_pht_entry_from_index(volatile page_hash_table db,
+                                               size_t index)
+    {
+      GC_acquire_dirty_lock();
+      set_pht_entry_from_index(db, index);
+      GC_release_dirty_lock();
+    }
+# else
+#   error No test_and_set operation: Introduces a race.
+# endif /* THREADS && !AO_HAVE_test_and_set_acquire */
+#endif /* !GC_DISABLE_INCREMENTAL */
 
   /* Mark the page containing p as dirty.  Logically, this dirties the  */
   /* entire object.                                                     */
@@ -3170,60 +3190,7 @@ GC_API GC_push_other_roots_proc GC_CALL GC_get_push_other_roots(void)
 # endif /* !MSWIN32 */
 #endif /* !DARWIN */
 
-#if defined(THREADS)
-/* We need to lock around the bitmap update in the write fault handler  */
-/* in order to avoid the risk of losing a bit.  We do this with a       */
-/* test-and-set spin lock if we know how to do that.  Otherwise we      */
-/* check whether we are already in the handler and use the dumb but     */
-/* safe fallback algorithm of setting all bits in the word.             */
-/* Contention should be very rare, so we do the minimum to handle it    */
-/* correctly.                                                           */
-#ifdef AO_HAVE_test_and_set_acquire
-  GC_INNER volatile AO_TS_t GC_fault_handler_lock = AO_TS_INITIALIZER;
-
-  GC_ATTR_NO_SANITIZE_THREAD
-  static void async_set_pht_entry_from_index(volatile page_hash_table db,
-                                             size_t index)
-  {
-    while (AO_test_and_set_acquire(&GC_fault_handler_lock) == AO_TS_SET) {
-      /* empty */
-    }
-    /* Could also revert to set_pht_entry_from_index_safe if initial    */
-    /* GC_test_and_set fails.                                           */
-    set_pht_entry_from_index(db, index);
-    AO_CLEAR(&GC_fault_handler_lock);
-  }
-#else /* !AO_HAVE_test_and_set_acquire */
-# error No test_and_set operation: Introduces a race.
-  /* THIS WOULD BE INCORRECT!                                           */
-  /* The dirty bit vector may be temporarily wrong,                     */
-  /* just before we notice the conflict and correct it. We may end up   */
-  /* looking at it while it's wrong.  But this requires contention      */
-  /* exactly when a GC is triggered, which seems far less likely to     */
-  /* fail than the old code, which had no reported failures.  Thus we   */
-  /* leave it this way while we think of something better, or support   */
-  /* GC_test_and_set on the remaining platforms.                        */
-  static int * volatile currently_updating = 0;
-  static void async_set_pht_entry_from_index(volatile page_hash_table db,
-                                             size_t index)
-  {
-    int update_dummy;
-    currently_updating = &update_dummy;
-    set_pht_entry_from_index(db, index);
-    /* If we get contention in the 10 or so instruction window here,    */
-    /* and we get stopped by a GC between the two updates, we lose!     */
-    if (currently_updating != &update_dummy) {
-        set_pht_entry_from_index_safe(db, index);
-        /* We claim that if two threads concurrently try to update the  */
-        /* dirty bit vector, the first one to execute UPDATE_START      */
-        /* will see it changed when UPDATE_END is executed.  (Note that */
-        /* &update_dummy must differ in two distinct threads.)  It      */
-        /* will then execute set_pht_entry_from_index_safe, thus        */
-        /* returning us to a safe state, though not soon enough.        */
-    }
-  }
-#endif /* !AO_HAVE_test_and_set_acquire */
-
+#ifdef THREADS
   /* This function is used only by the fault handler.  Potential data   */
   /* race between this function and GC_install_header, GC_remove_header */
   /* should not be harmful because the added or removed header should   */
@@ -3239,10 +3206,7 @@ GC_API GC_push_other_roots_proc GC_CALL GC_get_push_other_roots(void)
       return HDR_INNER(addr) != NULL;
 #   endif
   }
-
-#else /* !THREADS */
-# define async_set_pht_entry_from_index(db, index) \
-                        set_pht_entry_from_index(db, index)
+#else
 # define is_header_found_async(addr) (HDR(addr) != NULL)
 #endif /* !THREADS */
 

--- a/win32_threads.c
+++ b/win32_threads.c
@@ -1185,15 +1185,7 @@ STATIC void GC_suspend(GC_thread t)
       return;
     }
 # endif
-# if defined(MPROTECT_VDB)
-    /* Acquire the spin lock we use to update dirty bits.       */
-    /* Threads shouldn't get stopped holding it.  But we may    */
-    /* acquire and release it in the UNPROTECT_THREAD call.     */
-    while (AO_test_and_set_acquire(&GC_fault_handler_lock) == AO_TS_SET) {
-      /* empty */
-    }
-# endif
-
+  GC_acquire_dirty_lock();
 # ifdef MSWINCE
     /* SuspendThread() will fail if thread is running kernel code.      */
     while (SuspendThread(THREAD_HANDLE(t)) == (DWORD)-1)
@@ -1203,9 +1195,7 @@ STATIC void GC_suspend(GC_thread t)
       ABORT("SuspendThread failed");
 # endif /* !MSWINCE */
   t -> suspended = (unsigned char)TRUE;
-# if defined(MPROTECT_VDB)
-    AO_CLEAR(&GC_fault_handler_lock);
-# endif
+  GC_release_dirty_lock();
   if (GC_on_thread_event)
     GC_on_thread_event(GC_EVENT_THREAD_SUSPENDED, THREAD_HANDLE(t));
 }


### PR DESCRIPTION
Upstream bdwgc has some concurrency fixes related to manual vdb mode, where two concurrent calls to GC_dirty might lead to corrupt results. It seems we need those as well. As I did not dare to do a full update to upstream at this point, I backported those changes. 

I checked both mono and il2cpp to make sure everything still compiles.