### PR TITLE
Higher precision timers

### DIFF
--- a/alloc.c
+++ b/alloc.c
@@ -181,11 +181,11 @@ GC_INNER int GC_CALLBACK GC_never_stop_func(void)
 }
 
 #if defined(GC_TIME_LIMIT) && !defined(CPPCHECK)
-  unsigned long GC_time_limit = GC_TIME_LIMIT * 1000000;
+  unsigned long long GC_time_limit = GC_TIME_LIMIT * 1000000;
                            /* We try to keep pause times from exceeding  */
                            /* this by much. In milliseconds.             */
 #else
-  unsigned long GC_time_limit = 50000000;
+  unsigned long long GC_time_limit = 50000000;
 #endif
 
 #ifndef NO_CLOCK

--- a/alloc.c
+++ b/alloc.c
@@ -181,11 +181,11 @@ GC_INNER int GC_CALLBACK GC_never_stop_func(void)
 }
 
 #if defined(GC_TIME_LIMIT) && !defined(CPPCHECK)
-  unsigned long GC_time_limit = GC_TIME_LIMIT;
+  unsigned long GC_time_limit = GC_TIME_LIMIT * 1000000;
                            /* We try to keep pause times from exceeding  */
                            /* this by much. In milliseconds.             */
 #else
-  unsigned long GC_time_limit = 50;
+  unsigned long GC_time_limit = 50000000;
 #endif
 
 #ifndef NO_CLOCK
@@ -233,7 +233,7 @@ GC_API GC_stop_func GC_CALL GC_get_stop_func(void)
 
     if ((count++ & 3) != 0) return(0);
     GET_TIME(current_time);
-    time_diff = MS_TIME_DIFF(current_time,GC_start_time);
+    time_diff = NS_TIME_DIFF(current_time,GC_start_time);
     if (time_diff >= GC_time_limit) {
         GC_COND_LOG_PRINTF(
                 "Abandoning stopped marking after %lu msecs (attempt %d)\n",

--- a/include/gc.h
+++ b/include/gc.h
@@ -393,7 +393,9 @@ GC_API GC_ATTR_DEPRECATED unsigned long GC_time_limit;
                         /* avoid data races (if the value is modified   */
                         /* after the GC is put to multi-threaded mode). */
 GC_API void GC_CALL GC_set_time_limit(unsigned long);
+GC_API void GC_CALL GC_set_time_limit_ns(unsigned long);
 GC_API unsigned long GC_CALL GC_get_time_limit(void);
+GC_API unsigned long GC_CALL GC_get_time_limit_ns(void);
 
 /* Public procedures */
 

--- a/include/gc.h
+++ b/include/gc.h
@@ -375,7 +375,7 @@ GC_API GC_ATTR_DEPRECATED int GC_dont_precollect;
 GC_API void GC_CALL GC_set_dont_precollect(int);
 GC_API int GC_CALL GC_get_dont_precollect(void);
 
-GC_API GC_ATTR_DEPRECATED unsigned long GC_time_limit;
+GC_API GC_ATTR_DEPRECATED unsigned long long GC_time_limit;
                                /* If incremental collection is enabled, */
                                /* We try to terminate collections       */
                                /* after this many milliseconds.  Not a  */
@@ -384,7 +384,7 @@ GC_API GC_ATTR_DEPRECATED unsigned long GC_time_limit;
                                /* disable incremental collection while  */
                                /* leaving generational collection       */
                                /* enabled.                              */
-#define GC_TIME_UNLIMITED 999999
+#define GC_TIME_UNLIMITED 999999999999
                                /* Setting GC_time_limit to this value   */
                                /* will disable the "pause time exceeded"*/
                                /* tests.                                */
@@ -393,9 +393,9 @@ GC_API GC_ATTR_DEPRECATED unsigned long GC_time_limit;
                         /* avoid data races (if the value is modified   */
                         /* after the GC is put to multi-threaded mode). */
 GC_API void GC_CALL GC_set_time_limit(unsigned long);
-GC_API void GC_CALL GC_set_time_limit_ns(unsigned long);
+GC_API void GC_CALL GC_set_time_limit_ns(unsigned long long);
 GC_API unsigned long GC_CALL GC_get_time_limit(void);
-GC_API unsigned long GC_CALL GC_get_time_limit_ns(void);
+GC_API unsigned long long GC_CALL GC_get_time_limit_ns(void);
 
 /* Public procedures */
 

--- a/include/private/gc_priv.h
+++ b/include/private/gc_priv.h
@@ -444,14 +444,16 @@ EXTERN_C_END
 # define NOSERVICE
 # include <windows.h>
 # include <winbase.h>
-# define CLOCK_TYPE DWORD
-# ifdef MSWINRT_FLAVOR
-#   define GET_TIME(x) (void)(x = (DWORD)GetTickCount64())
-# else
-#   define GET_TIME(x) (void)(x = GetTickCount())
-# endif
-# define MS_TIME_DIFF(a,b) ((long)((a)-(b)))
-# define NS_TIME_DIFF(a,b) ((long)((a)-(b)) * 1000000)
+# define CLOCK_TYPE LONGLONG
+# define GET_TIME(x) \
+                do { \
+                  LARGE_INTEGER freq, t; \
+                  QueryPerformanceFrequency(&freq); \
+                  QueryPerformanceCounter(&t); \
+                  x = t.QuadPart * 1000000000 / freq.QuadPart; \
+                } while (0)
+# define MS_TIME_DIFF(a,b) (((a) - (b)) * 1000000)
+# define NS_TIME_DIFF(a,b) ((a) - (b))
 #elif defined(NN_PLATFORM_CTR)
 # define CLOCK_TYPE long long
   EXTERN_C_BEGIN

--- a/include/private/gc_priv.h
+++ b/include/private/gc_priv.h
@@ -435,8 +435,8 @@ EXTERN_C_END
                 } while (0)
 # define MS_TIME_DIFF(a,b) ((unsigned long)(a.tv_sec - b.tv_sec) * 1000 \
                             + (unsigned long)(a.tv_usec - b.tv_usec) / 1000)
-# define NS_TIME_DIFF(a,b) ((unsigned long)(a.tv_sec - b.tv_sec) * 1000000000 \
-                            + (unsigned long)(a.tv_usec - b.tv_usec) * 1000)
+# define NS_TIME_DIFF(a,b) ((unsigned long long)(a.tv_sec - b.tv_sec) * 1000000000 \
+                            + (unsigned long long)(a.tv_usec - b.tv_usec) * 1000)
 #elif defined(MSWIN32) || defined(MSWINCE)
 # ifndef WIN32_LEAN_AND_MEAN
 #   define WIN32_LEAN_AND_MEAN 1
@@ -462,7 +462,7 @@ EXTERN_C_END
   EXTERN_C_END
 # define GET_TIME(x) (void)(x = n3ds_get_system_tick())
 # define MS_TIME_DIFF(a,b) ((long)n3ds_convert_tick_to_ms((a)-(b)))
-# define NS_TIME_DIFF(a,b) ((long)n3ds_convert_tick_to_ms((a)-(b)) * 1000000)
+# define NS_TIME_DIFF(a,b) ((long long)n3ds_convert_tick_to_ms((a)-(b)) * 1000000)
 #else /* !BSD_TIME && !NN_PLATFORM_CTR && !MSWIN32 && !MSWINCE */
 # include <time.h>
 # if defined(FREEBSD) && !defined(CLOCKS_PER_SEC)
@@ -486,7 +486,7 @@ EXTERN_C_END
 # define MS_TIME_DIFF(a,b) (CLOCKS_PER_SEC % 1000 == 0 ? \
         (unsigned long)((a) - (b)) / (unsigned long)(CLOCKS_PER_SEC / 1000) \
         : ((unsigned long)((a) - (b)) * 1000) / (unsigned long)CLOCKS_PER_SEC)
-# define NS_TIME_DIFF(a,b) (((unsigned long)((a) - (b)) * 1000000000) / (unsigned long)CLOCKS_PER_SEC)
+# define NS_TIME_DIFF(a,b) (((unsigned long long)((a) - (b)) * 1000000000) / (unsigned long long)CLOCKS_PER_SEC)
   /* Avoid using double type since some targets (like ARM) might        */
   /* require -lm option for double-to-long conversion.                  */
 #endif /* !BSD_TIME && !MSWIN32 */

--- a/include/private/gc_priv.h
+++ b/include/private/gc_priv.h
@@ -435,6 +435,8 @@ EXTERN_C_END
                 } while (0)
 # define MS_TIME_DIFF(a,b) ((unsigned long)(a.tv_sec - b.tv_sec) * 1000 \
                             + (unsigned long)(a.tv_usec - b.tv_usec) / 1000)
+# define NS_TIME_DIFF(a,b) ((unsigned long)(a.tv_sec - b.tv_sec) * 1000000000 \
+                            + (unsigned long)(a.tv_usec - b.tv_usec) * 1000)
 #elif defined(MSWIN32) || defined(MSWINCE)
 # ifndef WIN32_LEAN_AND_MEAN
 #   define WIN32_LEAN_AND_MEAN 1
@@ -449,6 +451,7 @@ EXTERN_C_END
 #   define GET_TIME(x) (void)(x = GetTickCount())
 # endif
 # define MS_TIME_DIFF(a,b) ((long)((a)-(b)))
+# define NS_TIME_DIFF(a,b) ((long)((a)-(b)) * 1000000)
 #elif defined(NN_PLATFORM_CTR)
 # define CLOCK_TYPE long long
   EXTERN_C_BEGIN
@@ -457,6 +460,7 @@ EXTERN_C_END
   EXTERN_C_END
 # define GET_TIME(x) (void)(x = n3ds_get_system_tick())
 # define MS_TIME_DIFF(a,b) ((long)n3ds_convert_tick_to_ms((a)-(b)))
+# define NS_TIME_DIFF(a,b) ((long)n3ds_convert_tick_to_ms((a)-(b)) * 1000000)
 #else /* !BSD_TIME && !NN_PLATFORM_CTR && !MSWIN32 && !MSWINCE */
 # include <time.h>
 # if defined(FREEBSD) && !defined(CLOCKS_PER_SEC)
@@ -480,6 +484,7 @@ EXTERN_C_END
 # define MS_TIME_DIFF(a,b) (CLOCKS_PER_SEC % 1000 == 0 ? \
         (unsigned long)((a) - (b)) / (unsigned long)(CLOCKS_PER_SEC / 1000) \
         : ((unsigned long)((a) - (b)) * 1000) / (unsigned long)CLOCKS_PER_SEC)
+# define NS_TIME_DIFF(a,b) (((unsigned long)((a) - (b)) * 1000000000) / (unsigned long)CLOCKS_PER_SEC)
   /* Avoid using double type since some targets (like ARM) might        */
   /* require -lm option for double-to-long conversion.                  */
 #endif /* !BSD_TIME && !MSWIN32 */

--- a/misc.c
+++ b/misc.c
@@ -1105,7 +1105,7 @@ GC_API void GC_CALL GC_init(void)
             WARN("GC_PAUSE_TIME_TARGET environment variable value too small "
                  "or bad syntax: Ignoring\n", 0);
           } else {
-            GC_time_limit = time_limit;
+            GC_time_limit = time_limit * 1000000;
           }
         }
       }
@@ -2543,10 +2543,21 @@ GC_API int GC_CALL GC_get_full_freq(void)
 GC_API void GC_CALL GC_set_time_limit(unsigned long value)
 {
     GC_ASSERT(value != (unsigned long)-1L);
-    GC_time_limit = value;
+    GC_time_limit = value * 1000000;
 }
 
 GC_API unsigned long GC_CALL GC_get_time_limit(void)
+{
+    return GC_time_limit / 1000000;
+}
+
+GC_API void GC_CALL GC_set_time_limit_ns(unsigned long value)
+{
+    GC_ASSERT(value != (unsigned long)-1L);
+    GC_time_limit = value;
+}
+
+GC_API unsigned long GC_CALL GC_get_time_limit_ns(void)
 {
     return GC_time_limit;
 }

--- a/misc.c
+++ b/misc.c
@@ -2551,13 +2551,13 @@ GC_API unsigned long GC_CALL GC_get_time_limit(void)
     return GC_time_limit / 1000000;
 }
 
-GC_API void GC_CALL GC_set_time_limit_ns(unsigned long value)
+GC_API void GC_CALL GC_set_time_limit_ns(unsigned long long value)
 {
-    GC_ASSERT(value != (unsigned long)-1L);
+    GC_ASSERT(value != (unsigned long long)-1L);
     GC_time_limit = value;
 }
 
-GC_API unsigned long GC_CALL GC_get_time_limit_ns(void)
+GC_API unsigned long long GC_CALL GC_get_time_limit_ns(void)
 {
     return GC_time_limit;
 }


### PR DESCRIPTION
Based on the discussion in https://ono.unity3d.com/unity/unity/pull-request/76155/_/platform/foundation/incremental-gc-control2 , we concluded that we want the ability to specify GC_time_limit using nanosecond precision (though platform implementations may use a lower granularity for their timers).

This PR implements that. Tested on mac and windows in mono.