### PR TITLE
Higher precision timer - compilation fixes

### DIFF
--- a/alloc.c
+++ b/alloc.c
@@ -236,7 +236,7 @@ GC_API GC_stop_func GC_CALL GC_get_stop_func(void)
     time_diff = NS_TIME_DIFF(current_time,GC_start_time);
     if (time_diff >= GC_time_limit) {
         GC_COND_LOG_PRINTF(
-                "Abandoning stopped marking after %lu msecs (attempt %d)\n",
+                "Abandoning stopped marking after %lld nanoseconds (attempt %d)\n",
                 time_diff, GC_n_attempts);
         return(1);
     }

--- a/alloc.c
+++ b/alloc.c
@@ -226,7 +226,7 @@ GC_API GC_stop_func GC_CALL GC_get_stop_func(void)
   {
     CLOCK_TYPE current_time;
     static unsigned count = 0;
-    long long time_diff;
+    unsigned long long time_diff;
 
     if ((*GC_default_stop_func)())
       return(1);
@@ -236,7 +236,7 @@ GC_API GC_stop_func GC_CALL GC_get_stop_func(void)
     time_diff = NS_TIME_DIFF(current_time,GC_start_time);
     if (time_diff >= GC_time_limit) {
         GC_COND_LOG_PRINTF(
-                "Abandoning stopped marking after %lld nanoseconds (attempt %d)\n",
+                "Abandoning stopped marking after %llu nanoseconds (attempt %d)\n",
                 time_diff, GC_n_attempts);
         return(1);
     }

--- a/alloc.c
+++ b/alloc.c
@@ -226,7 +226,7 @@ GC_API GC_stop_func GC_CALL GC_get_stop_func(void)
   {
     CLOCK_TYPE current_time;
     static unsigned count = 0;
-    unsigned long time_diff;
+    long long time_diff;
 
     if ((*GC_default_stop_func)())
       return(1);

--- a/include/private/gc_priv.h
+++ b/include/private/gc_priv.h
@@ -452,7 +452,7 @@ EXTERN_C_END
                   QueryPerformanceCounter(&t); \
                   x = t.QuadPart * 1000000000 / freq.QuadPart; \
                 } while (0)
-# define MS_TIME_DIFF(a,b) (((a) - (b)) * 1000000)
+# define MS_TIME_DIFF(a,b) ((unsigned long)(((a) - (b)) * 1000000))
 # define NS_TIME_DIFF(a,b) ((a) - (b))
 #elif defined(NN_PLATFORM_CTR)
 # define CLOCK_TYPE long long

--- a/misc.c
+++ b/misc.c
@@ -2548,7 +2548,7 @@ GC_API void GC_CALL GC_set_time_limit(unsigned long value)
 
 GC_API unsigned long GC_CALL GC_get_time_limit(void)
 {
-    return GC_time_limit / 1000000;
+    return (unsigned long)(GC_time_limit / 1000000);
 }
 
 GC_API void GC_CALL GC_set_time_limit_ns(unsigned long long value)


### PR DESCRIPTION
I added higher timer precision in a previous PR, which we now also have in mono. But in il2cpp, we compile bdwgc with different warning flags, which caused il2cpp builds to fail due to cases where we downcast 64-bit to 32-bit integers. This PR fixes those compilation issues.