### PR TITLE
Switch back to LARGE_CONFIG

### DIFF
--- a/include/private/gcconfig.h
+++ b/include/private/gcconfig.h
@@ -3597,4 +3597,12 @@ EXTERN_C_BEGIN
 
 EXTERN_C_END
 
+#ifndef SMALL_CONFIG
+/* We were running out of memory due to the fact that 
+ * GC has a static sized array for heap segments, and without
+ * LARGE_CONFIG you go OOM at around 1.8 GB on 64-bit.
+ * Note, we define it everywhere on Mono. */
+#define LARGE_CONFIG
+#endif
+
 #endif /* GCCONFIG_H */


### PR DESCRIPTION
In the release-7_4 branch we had this code to configure bdwgc to use the large config. I overlooked that change when bringing unity-specific changes still needed to unity-master. As a result, we now have some Unity 18.3 users running into GC OOM errors for code which ran before, so we must bring this back.