### PR TITLE
Revert "use SP saved in context, avoids problems when on alternate signal stack"

### DIFF
--- a/pthread_stop_world.c
+++ b/pthread_stop_world.c
@@ -262,7 +262,7 @@ STATIC void GC_suspend_handler_inner(ptr_t dummy, void *context);
 # define GC_lookup_thread_async GC_lookup_thread
 #endif
 
-GC_INLINE void GC_store_stack_ptr(GC_thread me, void * context GC_ATTR_UNUSED)
+GC_INLINE void GC_store_stack_ptr(GC_thread me)
 {
   /* There is no data race between the suspend handler (storing         */
   /* stack_ptr) and GC_push_all_stacks (fetching stack_ptr) because     */
@@ -277,20 +277,8 @@ GC_INLINE void GC_store_stack_ptr(GC_thread me, void * context GC_ATTR_UNUSED)
 # else
 #   ifdef IA64
       me -> backing_store_ptr = GC_save_regs_in_stack();
-  /* For known architectures we support, use SP stored in context. */
-  /* This prevents disaster if we are running an alternate stack.  */
-#   elif defined(LINUX) && (defined(X86_64) || defined(I386))
-        ucontext_t* uc = (ucontext_t*)context;
-        AO_store((volatile AO_t *)&me->stop_info.stack_ptr,
-#       ifdef X86_64
-            (AO_t)uc->uc_mcontext.gregs[REG_RSP]
-#       else
-            (AO_t)uc->uc_mcontext.gregs[REG_ESP]
-#       endif
-        );
-#   else
-	    AO_store((volatile AO_t *)&me->stop_info.stack_ptr, (AO_t)GC_approx_sp());
 #   endif
+    AO_store((volatile AO_t *)&me->stop_info.stack_ptr, (AO_t)GC_approx_sp());
 # endif
 }
 
@@ -322,7 +310,7 @@ STATIC void GC_suspend_handler_inner(ptr_t dummy GC_ATTR_UNUSED,
 
 # ifdef GC_ENABLE_SUSPEND_THREAD
     if (AO_load(&me->suspended_ext)) {
-      GC_store_stack_ptr(me, context);
+      GC_store_stack_ptr(me);
       sem_post(&GC_suspend_ack_sem);
       suspend_self_inner(me);
 #     ifdef DEBUG_THREADS
@@ -342,7 +330,7 @@ STATIC void GC_suspend_handler_inner(ptr_t dummy GC_ATTR_UNUSED,
       RESTORE_CANCEL(cancel_state);
       return;
   }
-  GC_store_stack_ptr(me, context);
+  GC_store_stack_ptr(me);
 
 # ifdef THREAD_SANITIZER
     /* TSan disables signals around signal handlers.  Without   */


### PR DESCRIPTION
Reverts Unity-Technologies/bdwgc#26