### PR TITLE
Use atomics on ps4

### DIFF
--- a/include/private/gc_priv.h
+++ b/include/private/gc_priv.h
@@ -250,7 +250,7 @@ typedef char * ptr_t;   /* A generic pointer to which we can add        */
 # define GC_API_PRIV GC_API
 #endif
 
-#if defined(THREADS) && !defined(SN_TARGET_ORBIS) && !defined(SN_TARGET_PSP2) && !defined(NINTENDO_SWITCH)
+#if defined(THREADS) && !defined(SN_TARGET_PSP2) && !defined(NINTENDO_SWITCH)
 # include "gc_atomic_ops.h"
 #endif
 


### PR DESCRIPTION
Enable atomics on ps4, required to enable incremental GC support. Tested in il2cpp on PS4 katana builders here (https://katana.bf.unity3d.com/projects/Unity/builders?unity_branch=platform%2Fps4%2Finc-gc&search=ps4&hide_unstable=false) - will not land in mono as ps4 uses custom console mono branch.