### PR TITLE
Fix windows timers

### DIFF
--- a/include/private/gc_priv.h
+++ b/include/private/gc_priv.h
@@ -452,7 +452,7 @@ EXTERN_C_END
                   QueryPerformanceCounter(&t); \
                   x = t.QuadPart * 1000000000 / freq.QuadPart; \
                 } while (0)
-# define MS_TIME_DIFF(a,b) ((unsigned long)(((a) - (b)) * 1000000))
+# define MS_TIME_DIFF(a,b) ((unsigned long)(((a) - (b)) / 1000000))
 # define NS_TIME_DIFF(a,b) ((a) - (b))
 #elif defined(NN_PLATFORM_CTR)
 # define CLOCK_TYPE long long

--- a/include/private/gc_priv.h
+++ b/include/private/gc_priv.h
@@ -450,7 +450,7 @@ EXTERN_C_END
                   LARGE_INTEGER freq, t; \
                   QueryPerformanceFrequency(&freq); \
                   QueryPerformanceCounter(&t); \
-                  x = t.QuadPart * (1000000000.0 / (double)freq.QuadPart); \
+                  x = (LONGLONG)(t.QuadPart * (1000000000.0 / (double)freq.QuadPart)); \
                 } while (0)
 # define MS_TIME_DIFF(a,b) ((unsigned long)(((a) - (b)) / 1000000))
 # define NS_TIME_DIFF(a,b) ((a) - (b))

--- a/include/private/gc_priv.h
+++ b/include/private/gc_priv.h
@@ -450,7 +450,7 @@ EXTERN_C_END
                   LARGE_INTEGER freq, t; \
                   QueryPerformanceFrequency(&freq); \
                   QueryPerformanceCounter(&t); \
-                  x = t.QuadPart * 1000000000 / freq.QuadPart; \
+                  x = t.QuadPart * (1000000000.0 / (double)freq.QuadPart); \
                 } while (0)
 # define MS_TIME_DIFF(a,b) ((unsigned long)(((a) - (b)) / 1000000))
 # define NS_TIME_DIFF(a,b) ((a) - (b))


### PR DESCRIPTION
When  I updated the timers to use nanosecond precision, I made two mistakes in the windows version:
-MS_TIME_DIFF (used for debug time printing) took nanoseconds times 1000000 instead of divided by.
-t.QuadPart * 1000000000 could overflow. Using floating point math now instead.