### PR TITLE
Avoid setting the incremental flag when incremental is disabled

### DIFF
--- a/misc.c
+++ b/misc.c
@@ -2591,6 +2591,8 @@ GC_API void GC_CALL GC_disable_incremental(void)
 {
   LOCK();
   GC_gcollect_inner();
+#ifndef GC_DISABLE_INCREMENTAL
   GC_incremental = FALSE;
+#endif
   UNLOCK();
 }


### PR DESCRIPTION
If incremental GC is disabled, `GC_incremental` is not a variable, but
instead is define, so it cannot be set.

This corrects the build on platforms where incremental GC is disabled.