### PR TITLE
Avoid triggering a full GC when growing finalizer tables if in incremental mode

### DIFF
--- a/finalize.c
+++ b/finalize.c
@@ -124,7 +124,9 @@ STATIC void GC_grow_table(struct hash_chain_entry ***table,
     GC_ASSERT(I_HOLD_LOCK());
     /* Avoid growing the table in case of at least 25% of entries can   */
     /* be deleted by enforcing a collection.  Ignored for small tables. */
-    if (log_old_size >= GC_ON_GROW_LOG_SIZE_MIN) {
+    /* In incremental mode we skip this optimization, as we want to     */
+    /* avoid triggering a full GC whenever possible.                    */
+    if (log_old_size >= GC_ON_GROW_LOG_SIZE_MIN && !GC_incremental) {
       IF_CANCEL(int cancel_state;)
 
       DISABLE_CANCEL(cancel_state);


### PR DESCRIPTION
A user complained that his project would still trigger some full GCs while playing a game in Unity with incremental GC enabled. Upon debugging the problem, it turned out that this was caused by a path in the boehm finalizer table expansion code, which would trigger a full GC before growing the table, to see if this would let it avoid expanding the table.

While this approach can save memory, it will cause a full GC, which we want to avoid whenever possible when running in incremental mode. So, I decided to bypass this optimization in incremental mode.