### PR TITLE
Allow BDWGC to uninitialize and re-initialize

### DIFF
--- a/allchblk.c
+++ b/allchblk.c
@@ -64,6 +64,12 @@
   word GC_free_bytes[N_HBLK_FLS+1] = { 0 };
         /* Number of free bytes on each list.  Remains visible to GCJ.  */
 
+void GC_clear_freelist(void)
+{
+    memset(GC_hblkfreelist, 0, sizeof(GC_hblkfreelist));
+    memset(GC_free_bytes, 0, sizeof(GC_free_bytes));
+}
+
 /* Return the largest n such that the number of free bytes on lists     */
 /* n .. N_HBLK_FLS is greater or equal to GC_max_large_allocd_bytes     */
 /* minus GC_large_allocd_bytes.  If there is no such n, return 0.       */

--- a/finalize.c
+++ b/finalize.c
@@ -78,6 +78,13 @@ STATIC struct fnlz_roots_s {
   struct finalizable_object *finalize_now;
 } GC_fnlz_roots = { NULL, NULL };
 
+void GC_clear_finalizable_object_table()
+{
+    log_fo_table_size = -1;
+    GC_fnlz_roots.fo_head = NULL;
+    GC_fnlz_roots.finalize_now = NULL;
+}
+
 #ifdef AO_HAVE_store
   /* Update finalize_now atomically as GC_should_invoke_finalizers does */
   /* not acquire the allocation lock.                                   */

--- a/headers.c
+++ b/headers.c
@@ -32,6 +32,12 @@ STATIC bottom_index * GC_all_bottom_indices_end = 0;
                         /* Pointer to the last (highest address)        */
                         /* bottom_index.  Assumes the lock is held.     */
 
+void GC_clear_bottom_indices()
+{
+    GC_all_bottom_indices = 0;
+    GC_all_bottom_indices_end = 0;
+}
+
 /* Non-macro version of header location routine */
 GC_INNER hdr * GC_find_header(ptr_t h)
 {
@@ -194,10 +200,13 @@ GC_INNER void GC_init_headers(void)
 {
     unsigned i;
 
-    GC_all_nils = (bottom_index *)GC_scratch_alloc(sizeof(bottom_index));
-    if (GC_all_nils == NULL) {
-      GC_err_printf("Insufficient memory for GC_all_nils\n");
-      EXIT();
+    if (GC_all_nils == NULL)
+    {
+        GC_all_nils = (bottom_index *)GC_scratch_alloc(sizeof(bottom_index));
+        if (GC_all_nils == NULL) {
+          GC_err_printf("Insufficient memory for GC_all_nils\n");
+          EXIT();
+        }
     }
     BZERO(GC_all_nils, sizeof(bottom_index));
     for (i = 0; i < TOP_SZ; i++) {

--- a/include/gc.h
+++ b/include/gc.h
@@ -598,6 +598,9 @@ GC_API void GC_CALL GC_set_max_heap_size(GC_word /* n */);
 GC_API void GC_CALL GC_exclude_static_roots(void * /* low_address */,
                                             void * /* high_address_plus_1 */);
 
+/* Clear the number of entries in the exclustion table.  Wizards only.  */
+GC_API void GC_CALL GC_clear_exclusion_table(void);
+
 /* Clear the set of root segments.  Wizards only.                       */
 GC_API void GC_CALL GC_clear_roots(void);
 

--- a/mark.c
+++ b/mark.c
@@ -122,6 +122,17 @@ static struct hblk * scan_ptr;
 STATIC GC_bool GC_objects_are_marked = FALSE;
                 /* Are there collectible marked objects in the heap?    */
 
+void GC_reset_mark_statics()
+{
+     GC_n_mark_procs = GC_RESERVED_MARK_PROCS;
+     GC_n_kinds = GC_N_KINDS_INITIAL_VALUE;
+     GC_mark_stack_size = 0;
+     GC_mark_state = MS_NONE;
+     GC_mark_stack_too_small = FALSE;
+     scan_ptr = NULL;
+     GC_objects_are_marked = FALSE;
+}
+
 /* Is a collection in progress?  Note that this can return true in the  */
 /* nonincremental case, if a collection has been abandoned and the      */
 /* mark state is now MS_INVALID.                                        */

--- a/mark_rts.c
+++ b/mark_rts.c
@@ -512,6 +512,11 @@ struct exclusion GC_excl_table[MAX_EXCLUSIONS];
 
 STATIC size_t GC_excl_table_entries = 0;/* Number of entries in use.      */
 
+GC_API void GC_CALL GC_clear_exclusion_table(void)
+{
+    GC_excl_table_entries = 0;
+}
+
 /* Return the first exclusion range that includes an address >= start_addr */
 /* Assumes the exclusion table contains at least one entry (namely the     */
 /* GC data structures).                                                    */

--- a/misc.c
+++ b/misc.c
@@ -1430,11 +1430,14 @@ GC_API void GC_CALL GC_enable_incremental(void)
 #     endif
         GC_clear_exclusion_table();
         memset(&GC_arrays, 0, sizeof(GC_arrays));
+#     if defined(MSWIN32) || defined(MSWINCE)
         GC_win32_free_heap();
+#     endif
         GC_clear_freelist();
         GC_clear_bottom_indices();
         GC_clear_finalizable_object_table();
         GC_reset_mark_statics();
+        GC_reset_default_push_other_roots();
     }
   }
 

--- a/misc.c
+++ b/misc.c
@@ -1432,7 +1432,7 @@ GC_API void GC_CALL GC_enable_incremental(void)
 #     endif
         GC_clear_exclusion_table();
         memset(&GC_arrays, 0, sizeof(GC_arrays));
-#     if defined(MSWIN32) || defined(MSWINCE)
+#     if (defined(MSWIN32) || defined(MSWINCE)) && !defined(MSWIN_XBOX1)
         GC_win32_free_heap();
 #     endif
         GC_clear_freelist();

--- a/misc.c
+++ b/misc.c
@@ -1419,6 +1419,8 @@ GC_API void GC_CALL GC_enable_incremental(void)
   }
 #endif
 
+  extern void GC_reset_default_push_other_roots(void);
+
   GC_API void GC_CALL GC_deinit(void)
   {
     if (GC_is_initialized) {

--- a/misc.c
+++ b/misc.c
@@ -1428,6 +1428,13 @@ GC_API void GC_CALL GC_enable_incremental(void)
         DeleteCriticalSection(&GC_write_cs);
         DeleteCriticalSection(&GC_allocate_ml);
 #     endif
+        GC_clear_exclusion_table();
+        memset(&GC_arrays, 0, sizeof(GC_arrays));
+        GC_win32_free_heap();
+        GC_clear_freelist();
+        GC_clear_bottom_indices();
+        GC_clear_finalizable_object_table();
+        GC_reset_mark_statics();
     }
   }
 

--- a/os_dep.c
+++ b/os_dep.c
@@ -2791,7 +2791,11 @@ GC_API GC_push_other_roots_proc GC_CALL GC_get_push_other_roots(void)
 
 void GC_reset_default_push_other_roots(void)
 {
+#ifdef THREADS
     GC_push_other_roots = GC_default_push_other_roots;
+#else
+    GC_push_other_roots = 0;
+#endif
 }
 
 /*

--- a/os_dep.c
+++ b/os_dep.c
@@ -2789,6 +2789,11 @@ GC_API GC_push_other_roots_proc GC_CALL GC_get_push_other_roots(void)
     return GC_push_other_roots;
 }
 
+void GC_reset_default_push_other_roots(void)
+{
+    GC_push_other_roots = GC_default_push_other_roots;
+}
+
 /*
  * Routines for accessing dirty bits on virtual pages.
  * There are six ways to maintain this information:


### PR DESCRIPTION
These changes will be used by IL2CPP to allow BDWGC to uninitialize and re-initialize. For the most part, they cause static variables to be set back to their initial value.