### PR TITLE
Remove code that attempt to free the heap on Windows

### DIFF
--- a/misc.c
+++ b/misc.c
@@ -1432,9 +1432,6 @@ GC_API void GC_CALL GC_enable_incremental(void)
 #     endif
         GC_clear_exclusion_table();
         memset(&GC_arrays, 0, sizeof(GC_arrays));
-#     if (defined(MSWIN32) || defined(MSWINCE)) && !defined(MSWIN_XBOX1)
-        GC_win32_free_heap();
-#     endif
         GC_clear_freelist();
         GC_clear_bottom_indices();
         GC_clear_finalizable_object_table();


### PR DESCRIPTION
This causes problems in Unity for the UWP player when it unloads IL2CPP.

It looks like it was never actually necessary on Windows desktop either,
so let's remove it.