### PR TITLE
Really fix 'potential unsafe sign check of a bitwise operation' code …

### DIFF
--- a/mark.c
+++ b/mark.c
@@ -664,7 +664,8 @@ GC_INNER mse * GC_mark_from(mse *mark_stack_top, mse *mark_stack,
 # ifdef OS2 /* Use untweaked version to circumvent compiler problem */
     while ((word)mark_stack_top >= (word)mark_stack && credit >= 0)
 # else
-    while ((((ptr_t)mark_stack_top - (ptr_t)mark_stack) | credit) >= 0)
+    while (((((word)mark_stack_top - (word)mark_stack) | (word)credit)
+            & SIGNB) == 0)
 # endif
   {
     current_p = mark_stack_top -> mse_start;


### PR DESCRIPTION
…defect

(fix of commit af00c4d)

* mark.c [!OS2] (GC_mark_from): Replace (signed_word)v>=0 to (v&SIGNB)==0
(anyway, the compiler generates the same code).