### PR TITLE
Default GC_retry_signals=TRUE always

### DIFF
--- a/pthread_stop_world.c
+++ b/pthread_stop_world.c
@@ -128,7 +128,8 @@ STATIC volatile AO_t GC_world_is_stopped = FALSE;
     || defined(ADDRESS_SANITIZER) || defined(MEMORY_SANITIZER)
   STATIC GC_bool GC_retry_signals = TRUE;
 #else
-  STATIC GC_bool GC_retry_signals = FALSE;
+  // Unity: Always enable retry signals, since any platform could lose signals
+  STATIC GC_bool GC_retry_signals = TRUE;
 #endif
 
 /*


### PR DESCRIPTION
We saw GC lockups because of lost signals on Android.  Any platform
could lose signals, so we'll be conserative and always retry.