### PR TITLE
Add GC_trigger_collection API

### DIFF
--- a/alloc.c
+++ b/alloc.c
@@ -366,6 +366,12 @@ STATIC void GC_clear_a_few_frames(void)
 /* Heap size at which we need a collection to avoid expanding past      */
 /* limits used by blacklisting.                                         */
 STATIC word GC_collect_at_heapsize = (word)(-1);
+STATIC GC_bool GC_should_trigger_collection = FALSE;
+
+GC_API void GC_trigger_collection()
+{
+  GC_should_trigger_collection = TRUE;
+}
 
 /* Have we allocated enough to amortize a collection? */
 GC_INNER GC_bool GC_should_collect(void)
@@ -375,6 +381,11 @@ GC_INNER GC_bool GC_should_collect(void)
     if (last_gc_no != GC_gc_no) {
       last_gc_no = GC_gc_no;
       last_min_bytes_allocd = min_bytes_allocd();
+    }
+    if (GC_should_trigger_collection)
+    {
+      GC_should_trigger_collection = FALSE;
+      return TRUE;
     }
     return(GC_adj_bytes_allocd() >= last_min_bytes_allocd
            || GC_heapsize >= GC_collect_at_heapsize);

--- a/alloc.c
+++ b/alloc.c
@@ -366,11 +366,15 @@ STATIC void GC_clear_a_few_frames(void)
 /* Heap size at which we need a collection to avoid expanding past      */
 /* limits used by blacklisting.                                         */
 STATIC word GC_collect_at_heapsize = (word)(-1);
-STATIC GC_bool GC_should_trigger_collection = FALSE;
+STATIC GC_bool GC_should_start_incremental_collection = FALSE;
 
-GC_API void GC_trigger_collection()
+GC_API void GC_start_incremental_collection()
 {
-  GC_should_trigger_collection = TRUE;
+  if (GC_incremental)
+  {
+    GC_should_start_incremental_collection = TRUE;
+    GC_collect_a_little();
+  }
 }
 
 /* Have we allocated enough to amortize a collection? */
@@ -382,9 +386,9 @@ GC_INNER GC_bool GC_should_collect(void)
       last_gc_no = GC_gc_no;
       last_min_bytes_allocd = min_bytes_allocd();
     }
-    if (GC_should_trigger_collection)
+    if (GC_should_start_incremental_collection)
     {
-      GC_should_trigger_collection = FALSE;
+      GC_should_start_incremental_collection = FALSE;
       return TRUE;
     }
     return(GC_adj_bytes_allocd() >= last_min_bytes_allocd

--- a/include/gc.h
+++ b/include/gc.h
@@ -2034,6 +2034,7 @@ GC_API void GC_CALL GC_stop_world_external(void);
 GC_API void GC_CALL GC_start_world_external(void);
 
 GC_API void GC_CALL GC_disable_incremental(void);
+GC_API void GC_CALL GC_trigger_collection (void);
 
 /* APIs for getting access to raw GC heap */
 /* These are NOT thread safe, so should be called with GC lock held */

--- a/include/gc.h
+++ b/include/gc.h
@@ -2034,7 +2034,7 @@ GC_API void GC_CALL GC_stop_world_external(void);
 GC_API void GC_CALL GC_start_world_external(void);
 
 GC_API void GC_CALL GC_disable_incremental(void);
-GC_API void GC_CALL GC_trigger_collection (void);
+GC_API void GC_CALL GC_start_incremental_collection (void);
 
 /* APIs for getting access to raw GC heap */
 /* These are NOT thread safe, so should be called with GC lock held */


### PR DESCRIPTION
Currently, there is no way for external code to trigger an incremental collection in Boehm. You can call `GC_gcollect` which triggers a full, blocking collection, and `GC_collect_a_little` which performs a full GC or - if enabled - some incremental collection work, _if the GC thinks that now is a good time to do so_, but there is no way to tell the GC to start an incremental collection _now_. This would be useful to have, for instance for a game to decide to perform some house keeping during some time, where it knows it has some spare cycles (some intermission screen, etc). Unity has a `GarbageCollector.CollectIncremental` API, but that will only give time to the incremental GC if it would collect anyways, making its use limited. It would be better if it would also trigger an incremental collection, which is what this change to Boehm should enable.