### PR TITLE
Avoid exceeding the mark stack limit (case 1235202)

### DIFF
--- a/include/gc_vector.h
+++ b/include/gc_vector.h
@@ -53,6 +53,7 @@ GC_API GC_ATTR_MALLOC void * GC_CALL GC_gcj_vector_malloc(size_t /* lb */,
 
 GC_API struct GC_ms_entry *GC_CALL
 GC_gcj_vector_mark_proc (struct GC_ms_entry *mark_stack_ptr,
+  struct GC_ms_entry* mark_stack_limit,
   GC_descr element_desc,
   GC_word*start,
   GC_word*end,


### PR DESCRIPTION
Ensure we don't exceed the mark stack limit when marking precise arrays.

This will require updated call sites in mono and il2cpp.

Backporting:
2020.1