### PR TITLE
Add GC_set_disable_automatic_collection API to disable automatic peri…

### DIFF
--- a/alloc.c
+++ b/alloc.c
@@ -367,6 +367,12 @@ STATIC void GC_clear_a_few_frames(void)
 /* limits used by blacklisting.                                         */
 STATIC word GC_collect_at_heapsize = (word)(-1);
 STATIC GC_bool GC_should_start_incremental_collection = FALSE;
+STATIC GC_bool GC_disable_automatic_collection = FALSE;
+
+GC_API void GC_set_disable_automatic_collection(GC_bool disable)
+{
+  GC_disable_automatic_collection = disable;
+}
 
 GC_API void GC_start_incremental_collection()
 {
@@ -391,6 +397,8 @@ GC_INNER GC_bool GC_should_collect(void)
       GC_should_start_incremental_collection = FALSE;
       return TRUE;
     }
+    if (GC_disable_automatic_collection)
+      return FALSE;
     return(GC_adj_bytes_allocd() >= last_min_bytes_allocd
            || GC_heapsize >= GC_collect_at_heapsize);
 }

--- a/include/gc.h
+++ b/include/gc.h
@@ -2038,6 +2038,7 @@ GC_API void GC_CALL GC_start_world_external(void);
 
 GC_API void GC_CALL GC_disable_incremental(void);
 GC_API void GC_CALL GC_start_incremental_collection (void);
+GC_API void GC_CALL GC_set_disable_automatic_collection(int);
 
 /* APIs for getting access to raw GC heap */
 /* These are NOT thread safe, so should be called with GC lock held */


### PR DESCRIPTION
…odic collections

Unlike using `GC_disable`, GC will still happen when explicitly requested using `GC_gcollect` or `GC_start_incremental_collection`.

In combination with https://github.com/Unity-Technologies/bdwgc/pull/54, this lets a program take over the logic for deciding when (incremental) GC takes place, which is useful for some users running into memory issues with their projects. The idea is to expose this by adding a new `Manual` mode to https://docs.unity3d.com/2019.1/Documentation/ScriptReference/Scripting.GarbageCollector.GCMode.html