### PR TITLE
Use a specific Emscripten allocator for Tiny

### DIFF
--- a/include/private/gcconfig.h
+++ b/include/private/gcconfig.h
@@ -3591,6 +3591,9 @@ EXTERN_C_BEGIN
 # elif defined(HAIKU)
     ptr_t GC_haiku_get_mem(size_t bytes);
 #   define GET_MEM(bytes) (struct hblk*)GC_haiku_get_mem(bytes)
+# elif defined(EMSCRIPTEN_TINY)
+    void *emmalloc_memalign(size_t alignment, size_t size);
+#   define GET_MEM(bytes) (struct hblk*)emmalloc_memalign(GC_page_size, bytes)
 # else
     ptr_t GC_unix_get_mem(size_t bytes);
 #   define GET_MEM(bytes) (struct hblk *)GC_unix_get_mem(bytes)


### PR DESCRIPTION
This allocator allows the GC to use the same allocator as the rest of
Emscripten, to avoid unnecessary heap fragmentation. The Emscripten used
in full Unity doesn't have this feature yet, so we'll put this behind
a define that is only enabled for Tiny.