### PR TITLE
Add loop to handle abort error like in suspend logic.

### DIFF
--- a/darwin_stop_world.c
+++ b/darwin_stop_world.c
@@ -196,10 +196,12 @@ STATIC ptr_t GC_stack_range_for(ptr_t *phi, thread_act_t thread, GC_thread p,
     /* else */ {
       mach_msg_type_number_t thread_state_count = GC_MACH_THREAD_STATE_COUNT;
 
-      /* Get the thread state (registers, etc) */
-      kern_result = thread_get_state(thread, GC_MACH_THREAD_STATE,
+      do {
+        /* Get the thread state (registers, etc) */
+        kern_result = thread_get_state(thread, GC_MACH_THREAD_STATE,
                                      (natural_t *)&state,
                                      &thread_state_count);
+      } while (kern_result == KERN_ABORTED);
     }
 #   ifdef DEBUG_THREADS
       GC_log_printf("thread_get_state returns value = %d\n", kern_result);


### PR DESCRIPTION
Fixes random failures we see on CI.

Note we did a similar fix for the actual suspend call here: https://github.com/Unity-Technologies/bdwgc/pull/13