### PR TITLE
Fix linkage with a system libatomic_ops shared library

### DIFF
--- a/bdw-gc.pc.in
+++ b/bdw-gc.pc.in
@@ -6,5 +6,5 @@ includedir=@includedir@
 Name: Boehm-Demers-Weiser Conservative Garbage Collector
 Description: A garbage collector for C and C++
 Version: @PACKAGE_VERSION@
-Libs: -L${libdir} -lgc
+Libs: -L${libdir} @ATOMIC_OPS_LIBS@ -lgc
 Cflags: -I${includedir}

--- a/configure.ac
+++ b/configure.ac
@@ -1074,7 +1074,9 @@ AS_IF([test x"$with_libatomic_ops" = xno \
 AC_MSG_CHECKING([which libatomic_ops to use])
 AS_IF([test x"$with_libatomic_ops" != xno],
   [ AS_IF([test x"$with_libatomic_ops" != xnone -a x"$THREADS" != xnone],
-          [ AC_MSG_RESULT([external]) ],
+          [ AC_MSG_RESULT([external])
+            ATOMIC_OPS_LIBS="-latomic_ops"
+            AC_SUBST([ATOMIC_OPS_LIBS]) ],
           [ AC_MSG_RESULT([none])
             AS_IF([test x"$THREADS" != xnone],
                   [ AC_DEFINE([GC_BUILTIN_ATOMIC], [1],


### PR DESCRIPTION
Issue #247 (bdwgc).

When bdwgc is linked with the external libatomic_ops, bdw-gc.pc must
contain the needed dynamic libraries (such as -latomic_ops) otherwise
build of applications could fail on the link stage on some hosts:
* libgc.so: undefined reference to 'AO_fetch_compare_and_swap_emulation'
* libgc.so: undefined reference to 'AO_store_full_emulation'

So, this commit sets ATOMIC_OPS_LIBS to "-latomic_ops" when a system
atomic_ops library is used and uses ATOMIC_OPS_LIBS in bdw-gc.pc.in.

* bdw-gc.pc.in (Libs): Add @ATOMIC_OPS_LIBS@.
* configure.ac [$with_libatomic_ops!=no && $with_libatomic_ops!=none
&& $THREADS!=none] (ATOMIC_OPS_LIBS): Set to -latomic_ops; do AC_SUBST.

[Retrieved from:
https://github.com/ivmai/bdwgc/commit/02a44ee1df8176c72e75fd706d1a8f063d3196d5]

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>