### PR TITLE
Stop using git protocol for submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "libatomic_ops"]
 	path = libatomic_ops
-	url = git://github.com/Unity-Technologies/libatomic_ops.git
+	url = https://github.com/Unity-Technologies/libatomic_ops.git
 	branch = unity-release-7_4


### PR DESCRIPTION
GitHub is removing support for unencrypted git soon: https://github.blog/2021-09-01-improving-git-protocol-security-github/

@joncham 