### PR TITLE
Adding a call to allow the finalizer loop to be interrupted.

### DIFF
--- a/finalize.c
+++ b/finalize.c
@@ -1264,6 +1264,14 @@ GC_INNER void GC_finalize(void)
 
 #endif /* !JAVA_FINALIZATION_NOT_NEEDED */
 
+static volatile GC_bool GC_interrupt_finalizers = FALSE;
+
+void
+GC_set_interrupt_finalizers(void)
+{
+	GC_interrupt_finalizers = TRUE;
+}
+
 /* Returns true if it is worth calling GC_invoke_finalizers. (Useful if */
 /* finalizers can only be called from some kind of "safe state" and     */
 /* getting into that safe state is expensive.)                          */
@@ -1284,7 +1292,7 @@ GC_API int GC_CALL GC_invoke_finalizers(void)
     word bytes_freed_before = 0; /* initialized to prevent warning. */
     DCL_LOCK_STATE;
 
-    while (GC_should_invoke_finalizers()) {
+    while (GC_should_invoke_finalizers() && !GC_interrupt_finalizers) {
         struct finalizable_object * curr_fo;
 
 #       ifdef THREADS

--- a/include/gc.h
+++ b/include/gc.h
@@ -1294,6 +1294,10 @@ GC_API GC_await_finalize_proc GC_CALL GC_get_await_finalize_proc(void);
 /* Does not use any synchronization.                            */
 GC_API int GC_CALL GC_should_invoke_finalizers(void);
 
+/* Sets flag to signal GC_invoke_finalizers to break            */
+/* Does not use any synchronization.                            */
+GC_API void GC_CALL GC_set_interrupt_finalizers(void);
+
 GC_API int GC_CALL GC_invoke_finalizers(void);
         /* Run finalizers for all objects that are ready to     */
         /* be finalized.  Return the number of finalizers       */


### PR DESCRIPTION
GC_invoke_finalizers can take a long period of time to complete. During
Mono shutdown we need a way to safely stop the finalization of objects.