### PR TITLE
Fix incremental GC thread stack/register pushing on windows

### DIFF
--- a/include/private/gcconfig.h
+++ b/include/private/gcconfig.h
@@ -1531,6 +1531,7 @@ EXTERN_C_BEGIN
 #   ifdef CYGWIN32
 #       define OS_TYPE "CYGWIN32"
 #       define WOW64_THREAD_CONTEXT_WORKAROUND
+#       define RETRY_GET_THREAD_CONTEXT
 #       define DATASTART ((ptr_t)GC_DATASTART)  /* From gc.h */
 #       define DATAEND   ((ptr_t)GC_DATAEND)
 #       undef STACK_GRAN
@@ -1550,6 +1551,7 @@ EXTERN_C_BEGIN
 #   ifdef MSWIN32
 #       define OS_TYPE "MSWIN32"
 #       define WOW64_THREAD_CONTEXT_WORKAROUND
+#       define RETRY_GET_THREAD_CONTEXT
                 /* STACKBOTTOM and DATASTART are handled specially in   */
                 /* os_dep.c.                                            */
 #       define MPROTECT_VDB
@@ -2750,6 +2752,24 @@ EXTERN_C_BEGIN
 #         define HEAP_START DATAEND
 #       endif
 #   endif
+#   ifdef CYGWIN32
+#       define OS_TYPE "CYGWIN32"
+#       define RETRY_GET_THREAD_CONTEXT
+#       ifdef USE_WINALLOC
+#         define GWW_VDB
+#       else
+#         if defined(THREAD_LOCAL_ALLOC)
+            /* TODO: For an unknown reason, thread-local allocations    */
+            /* lead to spurious process exit after the fault handler is */
+            /* once invoked.                                            */
+#         else
+#           define MPROTECT_VDB
+#         endif
+#         ifdef USE_MMAP
+#           define USE_MMAP_ANON
+#         endif
+#       endif
+#   endif
 #   ifdef MSWIN_XBOX1
 #     define NO_GETENV
 #     define DATASTART (ptr_t)ALIGNMENT
@@ -2771,6 +2791,7 @@ EXTERN_C_BEGIN
 #   endif
 #   ifdef MSWIN32
 #       define OS_TYPE "MSWIN32"
+#       define RETRY_GET_THREAD_CONTEXT
                 /* STACKBOTTOM and DATASTART are handled specially in   */
                 /* os_dep.c.                                            */
 #       if !defined(__GNUC__) || defined(__INTEL_COMPILER) \
@@ -2863,6 +2884,10 @@ EXTERN_C_BEGIN
 #if defined(__GLIBC__) && !defined(DONT_USE_LIBC_PRIVATES)
   /* Use glibc's stack-end marker. */
 # define USE_LIBC_PRIVATES
+#endif
+
+#ifdef NO_RETRY_GET_THREAD_CONTEXT
+# undef RETRY_GET_THREAD_CONTEXT
 #endif
 
 #if defined(LINUX_STACKBOTTOM) && defined(NO_PROC_STAT) \

--- a/include/private/gcconfig.h
+++ b/include/private/gcconfig.h
@@ -1530,6 +1530,7 @@ EXTERN_C_BEGIN
 #   endif
 #   ifdef CYGWIN32
 #       define OS_TYPE "CYGWIN32"
+#       define WOW64_THREAD_CONTEXT_WORKAROUND
 #       define DATASTART ((ptr_t)GC_DATASTART)  /* From gc.h */
 #       define DATAEND   ((ptr_t)GC_DATAEND)
 #       undef STACK_GRAN
@@ -1548,6 +1549,7 @@ EXTERN_C_BEGIN
 #   endif
 #   ifdef MSWIN32
 #       define OS_TYPE "MSWIN32"
+#       define WOW64_THREAD_CONTEXT_WORKAROUND
                 /* STACKBOTTOM and DATASTART are handled specially in   */
                 /* os_dep.c.                                            */
 #       define MPROTECT_VDB

--- a/misc.c
+++ b/misc.c
@@ -812,9 +812,8 @@ GC_API int GC_CALL GC_is_init_called(void)
   }
 #endif
 
-#if defined(MSWIN32) && !defined(MSWINRT_FLAVOR) && (!defined(SMALL_CONFIG) \
-                         || (!defined(_WIN64) && defined(GC_WIN32_THREADS) \
-                             && defined(CHECK_NOT_WOW64))) && !defined(_XBOX_ONE)
+#if defined(MSWIN32) && !defined(MSWINRT_FLAVOR) && !defined(MSWIN_XBOX1) \
+    && !defined(SMALL_CONFIG)
   STATIC void GC_win32_MessageBoxA(const char *msg, const char *caption,
                                    unsigned flags)
   {
@@ -900,30 +899,6 @@ GC_API void GC_CALL GC_init(void)
       initial_heap_sz = GC_INITIAL_HEAP_SIZE;
 #   else
       initial_heap_sz = MINHINCR * HBLKSIZE;
-#   endif
-
-#   if defined(MSWIN32) && !defined(_WIN64) && defined(GC_WIN32_THREADS) \
-       && defined(CHECK_NOT_WOW64) && !defined(_XBOX_ONE)
-      {
-        /* Windows: running 32-bit GC on 64-bit system is broken!       */
-        /* WoW64 bug affects SuspendThread, no workaround exists.       */
-        HMODULE hK32 = GetModuleHandle(TEXT("kernel32.dll"));
-        if (hK32) {
-          FARPROC pfn = GetProcAddress(hK32, "IsWow64Process");
-          BOOL bIsWow64 = FALSE;
-          if (pfn
-              && (*(BOOL (WINAPI*)(HANDLE, BOOL*))pfn)(GetCurrentProcess(),
-                                                       &bIsWow64)
-              && bIsWow64) {
-            GC_win32_MessageBoxA("This program uses BDWGC garbage collector"
-                " compiled for 32-bit but running on 64-bit Windows.\n"
-                "This is known to be broken due to a design flaw"
-                " in Windows itself! Expect erratic behavior...",
-                "32-bit program running on 64-bit system",
-                MB_ICONWARNING | MB_OK);
-          }
-        }
-      }
 #   endif
 
     DISABLE_CANCEL(cancel_state);

--- a/win32_threads.c
+++ b/win32_threads.c
@@ -1509,6 +1509,7 @@ STATIC word GC_push_stack_for(GC_thread thread, DWORD me)
       /* require looping.                                               */
       word *regs = thread->context_regs;
 
+      GC_ASSERT(thread->suspended);
       sp = thread->context_sp;
 #   else
       /* For unblocked threads call GetThreadContext(). */
@@ -1516,6 +1517,7 @@ STATIC word GC_push_stack_for(GC_thread thread, DWORD me)
       {
         CONTEXT context;
 
+        GC_ASSERT(thread->suspended);
         context.ContextFlags = GET_THREAD_CONTEXT_FLAGS;
         if (!GetThreadContext(THREAD_HANDLE(thread), &context))
           ABORT("GetThreadContext failed");

--- a/win32_threads.c
+++ b/win32_threads.c
@@ -1162,6 +1162,21 @@ void GC_push_thread_structures(void)
 # endif
 }
 
+#ifdef WOW64_THREAD_CONTEXT_WORKAROUND
+# ifndef CONTEXT_EXCEPTION_ACTIVE
+#   define CONTEXT_EXCEPTION_ACTIVE    0x08000000
+#   define CONTEXT_EXCEPTION_REQUEST   0x40000000
+#   define CONTEXT_EXCEPTION_REPORTING 0x80000000
+# endif
+  static BOOL isWow64;  /* Is running 32-bit code on Win64?     */
+# define GET_THREAD_CONTEXT_FLAGS (isWow64 \
+                        ? CONTEXT_INTEGER | CONTEXT_CONTROL \
+                          | CONTEXT_EXCEPTION_REQUEST | CONTEXT_SEGMENTS \
+                        : CONTEXT_INTEGER | CONTEXT_CONTROL)
+#else
+# define GET_THREAD_CONTEXT_FLAGS (CONTEXT_INTEGER | CONTEXT_CONTROL)
+#endif /* !WOW64_THREAD_CONTEXT_WORKAROUND */
+
 /* Suspend the given thread, if it's still active.      */
 STATIC void GC_suspend(GC_thread t)
 {
@@ -1410,10 +1425,6 @@ static GC_bool may_be_in_stack(ptr_t s)
           && !(last_info.Protect & PAGE_GUARD);
 }
 
-#if defined(I386)
-  static BOOL isWow64;  /* Is running 32-bit code on Win64?     */
-#endif
-
 STATIC word GC_push_stack_for(GC_thread thread, DWORD me)
 {
   ptr_t sp, stack_min;
@@ -1427,22 +1438,8 @@ STATIC word GC_push_stack_for(GC_thread thread, DWORD me)
               /* Use saved sp value for blocked threads. */
     /* For unblocked threads call GetThreadContext().   */
     CONTEXT context;
-#   if defined(I386)
-#     ifndef CONTEXT_EXCEPTION_ACTIVE
-#       define CONTEXT_EXCEPTION_ACTIVE    0x08000000
-#       define CONTEXT_EXCEPTION_REQUEST   0x40000000
-#       define CONTEXT_EXCEPTION_REPORTING 0x80000000
-#     endif
 
-      if (isWow64) {
-        context.ContextFlags = CONTEXT_INTEGER | CONTEXT_CONTROL
-                                | CONTEXT_EXCEPTION_REQUEST
-                                | CONTEXT_SEGMENTS;
-      } else
-#   endif
-    /* else */ {
-      context.ContextFlags = CONTEXT_INTEGER | CONTEXT_CONTROL;
-    }
+    context.ContextFlags = GET_THREAD_CONTEXT_FLAGS;
     if (!GetThreadContext(THREAD_HANDLE(thread), &context))
       ABORT("GetThreadContext failed");
 
@@ -1454,45 +1451,7 @@ STATIC word GC_push_stack_for(GC_thread thread, DWORD me)
 #   define PUSH4(r1,r2,r3,r4) (PUSH2(r1,r2), PUSH2(r3,r4))
 #   if defined(I386)
       PUSH4(Edi,Esi,Ebx,Edx), PUSH2(Ecx,Eax), PUSH1(Ebp);
-      /* WoW64 workaround. */
-      if (isWow64
-          && (context.ContextFlags & CONTEXT_EXCEPTION_REPORTING) != 0
-          && (context.ContextFlags & (CONTEXT_EXCEPTION_ACTIVE
-                                      /* | CONTEXT_SERVICE_ACTIVE */)) != 0) {
-        LDT_ENTRY selector;
-        PNT_TIB tib;
-
-        if (!GetThreadSelectorEntry(THREAD_HANDLE(thread), context.SegFs,
-                                    &selector))
-          ABORT("GetThreadSelectorEntry failed");
-        tib = (PNT_TIB)(selector.BaseLow
-                        | (selector.HighWord.Bits.BaseMid << 16)
-                        | (selector.HighWord.Bits.BaseHi << 24));
-        /* GetThreadContext() might return stale register values, so    */
-        /* we scan the entire stack region (down to the stack limit).   */
-        /* There is no 100% guarantee that all the registers are pushed */
-        /* but we do our best (the proper solution would be to fix it   */
-        /* inside Windows OS).                                          */
-        sp = (ptr_t)tib->StackLimit;
-#       ifdef DEBUG_THREADS
-          GC_log_printf("TIB stack limit/base: %p .. %p\n",
-                        (void *)tib->StackLimit, (void *)tib->StackBase);
-#       endif
-        GC_ASSERT(!((word)thread->stack_base
-                    COOLER_THAN (word)tib->StackBase));
-      } else {
-#       ifdef DEBUG_THREADS
-          {
-            static GC_bool logged;
-            if (isWow64 && !logged
-                && (context.ContextFlags & CONTEXT_EXCEPTION_REPORTING) == 0) {
-              GC_log_printf("CONTEXT_EXCEPTION_REQUEST not supported\n");
-              logged = TRUE;
-            }
-          }
-#       endif
-        sp = (ptr_t)context.Esp;
-      }
+      sp = (ptr_t)context.Esp;
 #   elif defined(X86_64)
       PUSH4(Rax,Rcx,Rdx,Rbx); PUSH2(Rbp, Rsi); PUSH1(Rdi);
       PUSH4(R8, R9, R10, R11); PUSH4(R12, R13, R14, R15);
@@ -1530,8 +1489,61 @@ STATIC word GC_push_stack_for(GC_thread thread, DWORD me)
       PUSH4(IntT10,IntT11,IntT12,IntAt);
       sp = (ptr_t)context.IntSp;
 #   elif !defined(CPPCHECK)
-#     error "architecture is not supported"
+#     error Architecture is not supported
 #   endif
+#   ifdef WOW64_THREAD_CONTEXT_WORKAROUND
+      /* WoW64 workaround. */
+      if (isWow64
+          && (context.ContextFlags & CONTEXT_EXCEPTION_REPORTING) != 0
+          && (context.ContextFlags & (CONTEXT_EXCEPTION_ACTIVE
+                                      /* | CONTEXT_SERVICE_ACTIVE */)) != 0) {
+        LDT_ENTRY selector;
+        PNT_TIB tib;
+
+        if (!GetThreadSelectorEntry(THREAD_HANDLE(thread), context.SegFs,
+                                    &selector))
+          ABORT("GetThreadSelectorEntry failed");
+        tib = (PNT_TIB)(selector.BaseLow
+                        | (selector.HighWord.Bits.BaseMid << 16)
+                        | (selector.HighWord.Bits.BaseHi << 24));
+        /* GetThreadContext() might return stale register values, so    */
+        /* we scan the entire stack region (down to the stack limit).   */
+        /* There is no 100% guarantee that all the registers are pushed */
+        /* but we do our best (the proper solution would be to fix it   */
+        /* inside Windows OS).                                          */
+        sp = (ptr_t)tib->StackLimit;
+#       ifdef DEBUG_THREADS
+          GC_log_printf("TIB stack limit/base: %p .. %p\n",
+                        (void *)tib->StackLimit, (void *)tib->StackBase);
+#       endif
+        GC_ASSERT(!((word)thread->stack_base
+                    COOLER_THAN (word)tib->StackBase));
+        if (thread->stack_base != thread->initial_stack_base) {
+          /* We are in a coroutine.     */
+          if ((word)thread->stack_base <= (word)sp /* StackLimit */
+              || (word)tib->StackBase < (word)thread->stack_base) {
+            /* The coroutine stack is not within TIB stack.     */
+            sp = (ptr_t)context.Esp;
+            WARN("GetThreadContext might return stale register values"
+                 " including ESP=%p\n", sp);
+            /* TODO: Because of WoW64 bug, there is no guarantee that   */
+            /* sp really points to the stack top but, for now, we do    */
+            /* our best as the TIB stack limit/base cannot be used      */
+            /* while we are inside a coroutine.                         */
+          }
+        }
+      } /* else */
+#     ifdef DEBUG_THREADS
+        else {
+          static GC_bool logged;
+          if (isWow64 && !logged
+              && (context.ContextFlags & CONTEXT_EXCEPTION_REPORTING) == 0) {
+            GC_log_printf("CONTEXT_EXCEPTION_REQUEST not supported\n");
+            logged = TRUE;
+          }
+        }
+#     endif
+#   endif /* WOW64_THREAD_CONTEXT_WORKAROUND */
   } /* ! current thread */
 
   /* Set stack_min to the lowest address in the thread stack,   */
@@ -2525,7 +2537,7 @@ GC_INNER void GC_thr_init(void)
     }
 # endif
 
-# if defined(I386)
+# ifdef WOW64_THREAD_CONTEXT_WORKAROUND
     /* Set isWow64 flag. */
     {
       HMODULE hK32 = GetModuleHandle(TEXT("kernel32.dll"));

--- a/win32_threads.c
+++ b/win32_threads.c
@@ -74,6 +74,26 @@
 
 #endif /* !GC_PTHREADS && !MSWINCE */
 
+/* PUSHED_REGS_COUNT is the number of copied registers in copy_ptr_regs. */
+static ptr_t copy_ptr_regs(word *regs, const CONTEXT *pcontext);
+#if defined(I386)
+# ifdef WOW64_THREAD_CONTEXT_WORKAROUND
+#   define PUSHED_REGS_COUNT 9
+# else
+#   define PUSHED_REGS_COUNT 7
+# endif
+#elif defined(X86_64) || defined(SHx)
+# define PUSHED_REGS_COUNT 15
+#elif defined(ARM32)
+# define PUSHED_REGS_COUNT 13
+#elif defined(AARCH64)
+# define PUSHED_REGS_COUNT 30
+#elif defined(MIPS) || defined(ALPHA)
+# define PUSHED_REGS_COUNT 28
+#elif defined(PPC)
+# define PUSHED_REGS_COUNT 29
+#endif
+
 /* DllMain-based thread registration is currently incompatible  */
 /* with thread-local allocation, pthreads and WinCE.            */
 #if (defined(GC_DLL) || defined(GC_INSIDE_DLL)) \
@@ -246,14 +266,16 @@ struct GC_Thread_Rep {
 #   define KNOWN_FINISHED(t) 0
 # endif
 
-# ifdef RETRY_GET_THREAD_CONTEXT
-    CONTEXT saved_context; /* Populated as part of GC_suspend() as      */
-                           /* resume/suspend loop may be needed for the */
-                           /* call to GetThreadContext() to succeed.    */
-# endif
-
 # ifdef THREAD_LOCAL_ALLOC
     struct thread_local_freelists tlfs;
+# endif
+
+# ifdef RETRY_GET_THREAD_CONTEXT
+    ptr_t context_sp;
+    word context_regs[PUSHED_REGS_COUNT];
+                        /* Populated as part of GC_suspend() as         */
+                        /* resume/suspend loop may be needed for the    */
+                        /* call to GetThreadContext() to succeed.       */
 # endif
 };
 
@@ -1196,11 +1218,14 @@ STATIC void GC_suspend(GC_thread t)
 # elif defined(RETRY_GET_THREAD_CONTEXT)
     for (;;) {
       if (SuspendThread(t->handle) != (DWORD)-1) {
-        t->saved_context.ContextFlags = GET_THREAD_CONTEXT_FLAGS;
-        if (GetThreadContext(t->handle, &t->saved_context)) {
+        CONTEXT context;
+
+        context.ContextFlags = GET_THREAD_CONTEXT_FLAGS;
+        if (GetThreadContext(t->handle, &context)) {
           /* TODO: WoW64 extra workaround: if CONTEXT_EXCEPTION_ACTIVE  */
           /* then Sleep(1) and retry.                                   */
-          break; /* success; the context is saved */
+          t->context_sp = copy_ptr_regs(t->context_regs, &context);
+          break; /* success; the context pointer registers are saved */
         }
 
         /* Resume the thread, try to suspend it in a better location.   */
@@ -1404,38 +1429,23 @@ static GC_bool may_be_in_stack(ptr_t s)
           && !(last_info.Protect & PAGE_GUARD);
 }
 
-STATIC word GC_push_stack_for(GC_thread thread, DWORD me)
-{
-  ptr_t sp, stack_min;
-
-  struct GC_traced_stack_sect_s *traced_stack_sect =
-                                      thread -> traced_stack_sect;
-  if (thread -> id == me) {
-    GC_ASSERT(thread -> thread_blocked_sp == NULL);
-    sp = GC_approx_sp();
-  } else if ((sp = thread -> thread_blocked_sp) == NULL) {
-              /* Use saved sp value for blocked threads. */
-#   ifdef RETRY_GET_THREAD_CONTEXT
-      /* We cache context when suspending the thread since it may       */
-      /* require looping.                                               */
-      CONTEXT *pcontext = &thread->saved_context;
-#     define context (*pcontext)
-#   else
-      /* For unblocked threads call GetThreadContext(). */
-      CONTEXT context;
-
-      context.ContextFlags = GET_THREAD_CONTEXT_FLAGS;
-      if (!GetThreadContext(THREAD_HANDLE(thread), &context))
-        ABORT("GetThreadContext failed");
-#   endif
-
-    /* Push all registers that might point into the heap.  Frame        */
-    /* pointer registers are included in case client code was           */
-    /* compiled with the 'omit frame pointer' optimization.             */
-#   define PUSH1(reg) GC_push_one((word)context.reg)
+/* Copy all registers that might point into the heap.  Frame    */
+/* pointer registers are included in case client code was       */
+/* compiled with the 'omit frame pointer' optimization.         */
+/* The context register values are stored to regs argument      */
+/* which is expected to be of PUSHED_REGS_COUNT length exactly. */
+/* The functions returns the context stack pointer value.       */
+static ptr_t copy_ptr_regs(word *regs, const CONTEXT *pcontext) {
+    ptr_t sp;
+    int cnt = 0;
+#   define context (*pcontext)
+#   define PUSH1(reg) (regs[cnt++] = (word)pcontext->reg)
 #   define PUSH2(r1,r2) (PUSH1(r1), PUSH1(r2))
 #   define PUSH4(r1,r2,r3,r4) (PUSH2(r1,r2), PUSH2(r3,r4))
 #   if defined(I386)
+#     ifdef WOW64_THREAD_CONTEXT_WORKAROUND
+        PUSH2(ContextFlags, SegFs); /* cannot contain pointers */
+#     endif
       PUSH4(Edi,Esi,Ebx,Edx), PUSH2(Ecx,Eax), PUSH1(Ebp);
       sp = (ptr_t)context.Esp;
 #   elif defined(X86_64)
@@ -1477,62 +1487,103 @@ STATIC word GC_push_stack_for(GC_thread thread, DWORD me)
 #   elif !defined(CPPCHECK)
 #     error Architecture is not supported
 #   endif
+#   undef context
+    GC_ASSERT(cnt == PUSHED_REGS_COUNT);
+    return sp;
+}
+
+STATIC word GC_push_stack_for(GC_thread thread, DWORD me)
+{
+  ptr_t sp, stack_min;
+
+  struct GC_traced_stack_sect_s *traced_stack_sect =
+                                      thread -> traced_stack_sect;
+  if (thread -> id == me) {
+    GC_ASSERT(thread -> thread_blocked_sp == NULL);
+    sp = GC_approx_sp();
+  } else if ((sp = thread -> thread_blocked_sp) == NULL) {
+              /* Use saved sp value for blocked threads. */
+    int i = 0;
+#   ifdef RETRY_GET_THREAD_CONTEXT
+      /* We cache context when suspending the thread since it may       */
+      /* require looping.                                               */
+      word *regs = thread->context_regs;
+
+      sp = thread->context_sp;
+#   else
+      /* For unblocked threads call GetThreadContext(). */
+      word regs[PUSHED_REGS_COUNT];
+      {
+        CONTEXT context;
+
+        context.ContextFlags = GET_THREAD_CONTEXT_FLAGS;
+        if (!GetThreadContext(THREAD_HANDLE(thread), &context))
+          ABORT("GetThreadContext failed");
+        sp = copy_ptr_regs(regs, &context);
+      }
+#   endif
+
+#   ifdef WOW64_THREAD_CONTEXT_WORKAROUND
+      i += 2; /* skip ContextFlags and SegFs */
+#   endif
+    for (; i < PUSHED_REGS_COUNT; i++)
+      GC_push_one(regs[i]);
+
 #   ifdef WOW64_THREAD_CONTEXT_WORKAROUND
       /* WoW64 workaround. */
-      if (isWow64
-          && (context.ContextFlags & CONTEXT_EXCEPTION_REPORTING) != 0
-          && (context.ContextFlags & (CONTEXT_EXCEPTION_ACTIVE
-                                      /* | CONTEXT_SERVICE_ACTIVE */)) != 0) {
-        LDT_ENTRY selector;
-        PNT_TIB tib;
+      if (isWow64) {
+        DWORD ContextFlags = (DWORD)regs[0];
+        WORD SegFs = (WORD)regs[1];
 
-        if (!GetThreadSelectorEntry(THREAD_HANDLE(thread), context.SegFs,
-                                    &selector))
-          ABORT("GetThreadSelectorEntry failed");
-        tib = (PNT_TIB)(selector.BaseLow
-                        | (selector.HighWord.Bits.BaseMid << 16)
-                        | (selector.HighWord.Bits.BaseHi << 24));
-        /* GetThreadContext() might return stale register values, so    */
-        /* we scan the entire stack region (down to the stack limit).   */
-        /* There is no 100% guarantee that all the registers are pushed */
-        /* but we do our best (the proper solution would be to fix it   */
-        /* inside Windows OS).                                          */
-        sp = (ptr_t)tib->StackLimit;
-#       ifdef DEBUG_THREADS
-          GC_log_printf("TIB stack limit/base: %p .. %p\n",
-                        (void *)tib->StackLimit, (void *)tib->StackBase);
-#       endif
-        GC_ASSERT(!((word)thread->stack_base
-                    COOLER_THAN (word)tib->StackBase));
-        if (thread->stack_base != thread->initial_stack_base) {
-          /* We are in a coroutine.     */
-          if ((word)thread->stack_base <= (word)sp /* StackLimit */
-              || (word)tib->StackBase < (word)thread->stack_base) {
-            /* The coroutine stack is not within TIB stack.     */
-            sp = (ptr_t)context.Esp;
+        if ((ContextFlags & CONTEXT_EXCEPTION_REPORTING) != 0
+            && (ContextFlags & (CONTEXT_EXCEPTION_ACTIVE
+                                /* | CONTEXT_SERVICE_ACTIVE */)) != 0) {
+          LDT_ENTRY selector;
+          PNT_TIB tib;
+
+          if (!GetThreadSelectorEntry(THREAD_HANDLE(thread), SegFs, &selector))
+            ABORT("GetThreadSelectorEntry failed");
+          tib = (PNT_TIB)(selector.BaseLow
+                          | (selector.HighWord.Bits.BaseMid << 16)
+                          | (selector.HighWord.Bits.BaseHi << 24));
+#         ifdef DEBUG_THREADS
+            GC_log_printf("TIB stack limit/base: %p .. %p\n",
+                          (void *)tib->StackLimit, (void *)tib->StackBase);
+#         endif
+          GC_ASSERT(!((word)thread->stack_base
+                      COOLER_THAN (word)tib->StackBase));
+          if (thread->stack_base != thread->initial_stack_base
+              /* We are in a coroutine. */
+              && ((word)thread->stack_base <= (word)tib->StackLimit
+                  || (word)tib->StackBase < (word)thread->stack_base)) {
+            /* The coroutine stack is not within TIB stack.   */
             WARN("GetThreadContext might return stale register values"
                  " including ESP=%p\n", sp);
             /* TODO: Because of WoW64 bug, there is no guarantee that   */
             /* sp really points to the stack top but, for now, we do    */
             /* our best as the TIB stack limit/base cannot be used      */
             /* while we are inside a coroutine.                         */
+          } else {
+            /* GetThreadContext() might return stale register values,   */
+            /* so we scan the entire stack region (down to the stack    */
+            /* limit).  There is no 100% guarantee that all the         */
+            /* registers are pushed but we do our best (the proper      */
+            /* solution would be to fix it inside Windows OS).          */
+            sp = (ptr_t)tib->StackLimit;
           }
-        }
-      } /* else */
-#     ifdef DEBUG_THREADS
-        else {
-          static GC_bool logged;
-          if (isWow64 && !logged
-              && (context.ContextFlags & CONTEXT_EXCEPTION_REPORTING) == 0) {
-            GC_log_printf("CONTEXT_EXCEPTION_REQUEST not supported\n");
-            logged = TRUE;
+        } /* else */
+#       ifdef DEBUG_THREADS
+          else {
+            static GC_bool logged;
+            if (!logged
+                && (ContextFlags & CONTEXT_EXCEPTION_REPORTING) == 0) {
+              GC_log_printf("CONTEXT_EXCEPTION_REQUEST not supported\n");
+              logged = TRUE;
+            }
           }
-        }
-#     endif
+#       endif
+      }
 #   endif /* WOW64_THREAD_CONTEXT_WORKAROUND */
-#   ifdef RETRY_GET_THREAD_CONTEXT
-#     undef context
-#   endif
   } /* ! current thread */
 
   /* Set stack_min to the lowest address in the thread stack,   */

--- a/win32_threads.c
+++ b/win32_threads.c
@@ -1573,6 +1573,7 @@ STATIC word GC_push_stack_for(GC_thread thread, DWORD me)
 #         endif
           GC_ASSERT(!((word)thread->stack_base
                       COOLER_THAN (word)tib->StackBase));
+#         ifdef UNITY_MISSING_COMMIT_5668de71
           if (thread->stack_base != thread->initial_stack_base
               /* We are in a coroutine. */
               && ((word)thread->stack_base <= (word)tib->StackLimit
@@ -1584,7 +1585,9 @@ STATIC word GC_push_stack_for(GC_thread thread, DWORD me)
             /* sp really points to the stack top but, for now, we do    */
             /* our best as the TIB stack limit/base cannot be used      */
             /* while we are inside a coroutine.                         */
-          } else {
+          } else
+#         endif
+          {
             /* GetThreadContext() might return stale register values,   */
             /* so we scan the entire stack region (down to the stack    */
             /* limit).  There is no 100% guarantee that all the         */

--- a/win32_threads.c
+++ b/win32_threads.c
@@ -352,8 +352,8 @@ STATIC volatile LONG GC_max_thread_index = 0;
 STATIC GC_thread GC_threads[THREAD_TABLE_SZ];
 
 /* It may not be safe to allocate when we register the first thread.    */
-/* Thus we allocated one statically.  It does not contain any field we  */
-/* need to push ("next" and "status" fields are unused).                */
+/* Thus we allocated one statically.  It does not contain any pointer   */
+/* field we need to push ("next" and "status" fields are unused).       */
 static struct GC_Thread_Rep first_thread;
 static GC_bool first_thread_used = FALSE;
 
@@ -693,6 +693,9 @@ STATIC void GC_delete_gc_thread_no_free(GC_vthread t)
       /* see GC_stop_world() for the information.                       */
       t -> stack_base = 0;
       t -> id = 0;
+#     ifdef RETRY_GET_THREAD_CONTEXT
+        t -> context_sp = NULL;
+#     endif
       AO_store_release(&t->tm.in_use, FALSE);
     } else
 # endif
@@ -1509,20 +1512,36 @@ STATIC word GC_push_stack_for(GC_thread thread, DWORD me)
       /* require looping.                                               */
       word *regs = thread->context_regs;
 
-      GC_ASSERT(thread->suspended);
-      sp = thread->context_sp;
+      if (thread->suspended) {
+        sp = thread->context_sp;
+      } else
 #   else
-      /* For unblocked threads call GetThreadContext(). */
       word regs[PUSHED_REGS_COUNT];
-      {
+#   endif
+
+      /* else */ {
         CONTEXT context;
 
-        GC_ASSERT(thread->suspended);
+        /* For unblocked threads call GetThreadContext().       */
         context.ContextFlags = GET_THREAD_CONTEXT_FLAGS;
-        if (!GetThreadContext(THREAD_HANDLE(thread), &context))
-          ABORT("GetThreadContext failed");
-        sp = copy_ptr_regs(regs, &context);
+        if (GetThreadContext(THREAD_HANDLE(thread), &context)) {
+          sp = copy_ptr_regs(regs, &context);
+        } else {
+#         ifdef RETRY_GET_THREAD_CONTEXT
+            /* At least, try to use the stale context if saved. */
+            sp = thread->context_sp;
+            if (NULL == sp) {
+              /* Skip the current thread, anyway its stack will */
+              /* be pushed when the world is stopped.           */
+              return 0;
+            }
+#         else
+            ABORT("GetThreadContext failed");
+#         endif
+        }
       }
+#   ifdef THREAD_LOCAL_ALLOC
+      GC_ASSERT(thread->suspended || !GC_world_stopped);
 #   endif
 
 #   ifdef WOW64_THREAD_CONTEXT_WORKAROUND
@@ -1670,6 +1689,8 @@ STATIC word GC_push_stack_for(GC_thread thread, DWORD me)
   return thread->stack_base - sp; /* stack grows down */
 }
 
+/* We hold allocation lock.  Should do exactly the right thing if the   */
+/* world is stopped.  Should not fail if it isn't.                      */
 GC_INNER void GC_push_all_stacks(void)
 {
   DWORD thread_id = GetCurrentThreadId();

--- a/win32_threads.c
+++ b/win32_threads.c
@@ -1410,6 +1410,10 @@ static GC_bool may_be_in_stack(ptr_t s)
           && !(last_info.Protect & PAGE_GUARD);
 }
 
+#if defined(I386)
+  static BOOL isWow64;  /* Is running 32-bit code on Win64?     */
+#endif
+
 STATIC word GC_push_stack_for(GC_thread thread, DWORD me)
 {
   ptr_t sp, stack_min;
@@ -1422,8 +1426,25 @@ STATIC word GC_push_stack_for(GC_thread thread, DWORD me)
   } else if ((sp = thread -> thread_blocked_sp) == NULL) {
               /* Use saved sp value for blocked threads. */
     /* For unblocked threads call GetThreadContext().   */
-    /* we cache context when suspending the thread since it may require looping */
-    CONTEXT context = thread->saved_context;
+    CONTEXT context;
+#   if defined(I386)
+#     ifndef CONTEXT_EXCEPTION_ACTIVE
+#       define CONTEXT_EXCEPTION_ACTIVE    0x08000000
+#       define CONTEXT_EXCEPTION_REQUEST   0x40000000
+#       define CONTEXT_EXCEPTION_REPORTING 0x80000000
+#     endif
+
+      if (isWow64) {
+        context.ContextFlags = CONTEXT_INTEGER | CONTEXT_CONTROL
+                                | CONTEXT_EXCEPTION_REQUEST
+                                | CONTEXT_SEGMENTS;
+      } else
+#   endif
+    /* else */ {
+      context.ContextFlags = CONTEXT_INTEGER | CONTEXT_CONTROL;
+    }
+    if (!GetThreadContext(THREAD_HANDLE(thread), &context))
+      ABORT("GetThreadContext failed");
 
     /* Push all registers that might point into the heap.  Frame        */
     /* pointer registers are included in case client code was           */
@@ -1433,7 +1454,45 @@ STATIC word GC_push_stack_for(GC_thread thread, DWORD me)
 #   define PUSH4(r1,r2,r3,r4) (PUSH2(r1,r2), PUSH2(r3,r4))
 #   if defined(I386)
       PUSH4(Edi,Esi,Ebx,Edx), PUSH2(Ecx,Eax), PUSH1(Ebp);
-      sp = (ptr_t)context.Esp;
+      /* WoW64 workaround. */
+      if (isWow64
+          && (context.ContextFlags & CONTEXT_EXCEPTION_REPORTING) != 0
+          && (context.ContextFlags & (CONTEXT_EXCEPTION_ACTIVE
+                                      /* | CONTEXT_SERVICE_ACTIVE */)) != 0) {
+        LDT_ENTRY selector;
+        PNT_TIB tib;
+
+        if (!GetThreadSelectorEntry(THREAD_HANDLE(thread), context.SegFs,
+                                    &selector))
+          ABORT("GetThreadSelectorEntry failed");
+        tib = (PNT_TIB)(selector.BaseLow
+                        | (selector.HighWord.Bits.BaseMid << 16)
+                        | (selector.HighWord.Bits.BaseHi << 24));
+        /* GetThreadContext() might return stale register values, so    */
+        /* we scan the entire stack region (down to the stack limit).   */
+        /* There is no 100% guarantee that all the registers are pushed */
+        /* but we do our best (the proper solution would be to fix it   */
+        /* inside Windows OS).                                          */
+        sp = (ptr_t)tib->StackLimit;
+#       ifdef DEBUG_THREADS
+          GC_log_printf("TIB stack limit/base: %p .. %p\n",
+                        (void *)tib->StackLimit, (void *)tib->StackBase);
+#       endif
+        GC_ASSERT(!((word)thread->stack_base
+                    COOLER_THAN (word)tib->StackBase));
+      } else {
+#       ifdef DEBUG_THREADS
+          {
+            static GC_bool logged;
+            if (isWow64 && !logged
+                && (context.ContextFlags & CONTEXT_EXCEPTION_REPORTING) == 0) {
+              GC_log_printf("CONTEXT_EXCEPTION_REQUEST not supported\n");
+              logged = TRUE;
+            }
+          }
+#       endif
+        sp = (ptr_t)context.Esp;
+      }
 #   elif defined(X86_64)
       PUSH4(Rax,Rcx,Rdx,Rbx); PUSH2(Rbp, Rsi); PUSH1(Rdi);
       PUSH4(R8, R9, R10, R11); PUSH4(R12, R13, R14, R15);
@@ -2463,6 +2522,20 @@ GC_INNER void GC_thr_init(void)
 #     endif
       /* else */ if (GC_handle_fork != -1)
         ABORT("pthread_atfork failed");
+    }
+# endif
+
+# if defined(I386)
+    /* Set isWow64 flag. */
+    {
+      HMODULE hK32 = GetModuleHandle(TEXT("kernel32.dll"));
+      if (hK32) {
+        FARPROC pfn = GetProcAddress(hK32, "IsWow64Process");
+        if (pfn
+            && !(*(BOOL (WINAPI*)(HANDLE, BOOL*))pfn)(GetCurrentProcess(),
+                                                      &isWow64))
+          isWow64 = FALSE; /* IsWow64Process failed */
+      }
     }
 # endif
 


### PR DESCRIPTION
Applies multiple patches from upstream to refactor how thread suspension and stack scanning is performed. The previous PR I made was incompatible with incremental mode. This was discussed on the following commit in the past but I missed the end of the discussion: https://github.com/Unity-Technologies/bdwgc/commit/3f39ea8e2e79c4d85db445aef97742eec4d56849

I applied the patches in entirety rather than trying to hand apply the fixes on our previous approach, or only the pieces we think we need.

Fixes case 1411601.