### PR TITLE
Fix 'undefined reference to __data_start' linker error (Android/aarch64)

### DIFF
--- a/include/private/gcconfig.h
+++ b/include/private/gcconfig.h
@@ -2268,9 +2268,16 @@ EXTERN_C_BEGIN
 #     define OS_TYPE "LINUX"
 #     define LINUX_STACKBOTTOM
 #     define DYNAMIC_LOADING
-      extern int __data_start[];
+#     if defined(HOST_ANDROID)
+#       define SEARCH_FOR_DATA_START
+                        /* As of NDK r18b, __data_start is not provided */
+                        /* if "gold" linker is used.  But __dso_handle  */
+                        /* symbol should be usable instead.             */
+#     else
+        extern int __data_start[];
+#       define DATASTART ((ptr_t)__data_start)
+#     endif
       extern int _end[];
-#     define DATASTART ((ptr_t)__data_start)
 #     define DATAEND ((ptr_t)(&_end))
 #   endif
 #   ifdef DARWIN


### PR DESCRIPTION
This fix is needed to make embed-bitcode option work with Android NDK r23b.

Before r23b, we used bfd linker for Arm64 which apparently defined this symbol.
With r23b, we switch to lld and the symbol is no longer there, hence the fix is needed.

Confirmed to work locally.