### PR TITLE
Fix linker error on bitcode target (case UUM-892).

### DIFF
--- a/os_dep.c
+++ b/os_dep.c
@@ -1535,7 +1535,15 @@ GC_INNER size_t GC_page_size = 0;
 /* added later then they need to be registered at that point (as we do  */
 /* with SunOS dynamic loading), or GC_mark_roots needs to check for     */
 /* them (as we do with PCR).  Called with allocator lock held.          */
-# ifdef OS2
+# if !defined(DYNAMIC_LOADING) && defined(GC_DONT_REGISTER_MAIN_STATIC_DATA)
+
+void GC_register_data_segments(void)
+{
+  /* This will never be called, but stub out empty function to avoid
+   * potential linker errors such as when compiling to bitcode. */
+}
+
+# elif defined(OS2)
 
 void GC_register_data_segments(void)
 {


### PR DESCRIPTION
Under the defines Unity provides,
!defined(DYNAMIC_LOADING) && defined(GC_DONT_REGISTER_MAIN_STATIC_DATA), GC_register_data_segments will never be called. However, the function was still present and referenced symbols not present when targeting bitcode. If the linker didn't remove the dead function, linker errors occured. Stub an empty function in this case.