### PR TITLE
Fix overflow marking ephemerons (case UUM-25411)

### DIFF
--- a/include/gc_mark.h
+++ b/include/gc_mark.h
@@ -313,7 +313,7 @@ GC_API void GC_CALL GC_print_trace_inner(GC_word /* gc_no */);
 /* Set the client for when mark stack is empty.  A client can use       */
 /* this callback to process (un)marked objects and push additional      */
 /* work onto the stack. Useful for implementing ephemerons.             */
-typedef void (GC_CALLBACK* GC_mark_stack_empty_proc)(void);
+typedef int (GC_CALLBACK* GC_mark_stack_empty_proc)(void);
 GC_API void GC_CALL GC_set_mark_stack_empty (GC_mark_stack_empty_proc);
 GC_API GC_mark_stack_empty_proc GC_CALL GC_get_mark_stack_empty (void);
 

--- a/mark.c
+++ b/mark.c
@@ -412,8 +412,15 @@ static void alloc_mark_stack(size_t);
                     GC_mark_stack_empty_called = FALSE;
                     return(TRUE);
                   } else {
-                    if (mark_stack_empty_proc != 0)
-                      mark_stack_empty_proc();
+                    if (mark_stack_empty_proc != 0) {
+                      if (!mark_stack_empty_proc()) {
+                        /* processing could not be completed */
+                        /* increase mark stack and to try again */
+                        GC_mark_state = MS_NONE;
+                        alloc_mark_stack(2 * GC_mark_stack_size);
+                        return(TRUE);
+                      }
+                    }
 
                     /* break below here loops us around the mark phase once again */
                     /* to process any items push by the callback */

--- a/os_dep.c
+++ b/os_dep.c
@@ -2809,7 +2809,7 @@ void GC_reset_default_push_other_roots(void)
 #endif
 }
 
-GC_push_other_roots_proc GC_on_mark_stack_empty;
+GC_mark_stack_empty_proc GC_on_mark_stack_empty;
 
 GC_API void GC_CALL GC_set_mark_stack_empty (GC_mark_stack_empty_proc fn)
 {


### PR DESCRIPTION
When marking ephemerons results in pushing a large number of objects, the mark stack may overflow. While processing could be batched, the simplest approach is to allow the callback to return FALSE to indicate failure and increasing the mark stack size.