### PR TITLE
Improve overflow fix for ephemerons.

### DIFF
--- a/include/gc_mark.h
+++ b/include/gc_mark.h
@@ -313,7 +313,9 @@ GC_API void GC_CALL GC_print_trace_inner(GC_word /* gc_no */);
 /* Set the client for when mark stack is empty.  A client can use       */
 /* this callback to process (un)marked objects and push additional      */
 /* work onto the stack. Useful for implementing ephemerons.             */
-typedef int (GC_CALLBACK* GC_mark_stack_empty_proc)(void);
+typedef struct GC_ms_entry* (GC_CALLBACK* GC_mark_stack_empty_proc)(
+  struct GC_ms_entry* /* mark_stack_ptr */,
+  struct GC_ms_entry* /* mark_stack_limit */);
 GC_API void GC_CALL GC_set_mark_stack_empty (GC_mark_stack_empty_proc);
 GC_API GC_mark_stack_empty_proc GC_CALL GC_get_mark_stack_empty (void);
 

--- a/mark.c
+++ b/mark.c
@@ -116,7 +116,6 @@ GC_INNER size_t GC_mark_stack_size = 0;
 GC_INNER mark_state_t GC_mark_state = MS_NONE;
 
 GC_INNER GC_bool GC_mark_stack_too_small = FALSE;
-GC_INNER GC_bool GC_mark_stack_empty_called = FALSE;
 
 static struct hblk * scan_ptr;
 
@@ -407,25 +406,16 @@ static void alloc_mark_stack(size_t);
                     return(TRUE);
                 } else {
                   GC_mark_stack_empty_proc mark_stack_empty_proc = GC_get_mark_stack_empty();
-                  if (GC_mark_stack_empty_called || !mark_stack_empty_proc) {
-                    GC_mark_state = MS_NONE;
-                    GC_mark_stack_empty_called = FALSE;
-                    return(TRUE);
-                  } else {
-                    if (mark_stack_empty_proc != 0) {
-                      if (!mark_stack_empty_proc()) {
-                        /* processing could not be completed */
-                        /* increase mark stack and to try again */
-                        GC_mark_state = MS_NONE;
-                        alloc_mark_stack(2 * GC_mark_stack_size);
-                        return(TRUE);
-                      }
-                    }
-
-                    /* break below here loops us around the mark phase once again */
-                    /* to process any items push by the callback */
-                    GC_mark_stack_empty_called = TRUE;
+                  if (mark_stack_empty_proc) {
+                      GC_mark_stack_top = mark_stack_empty_proc(GC_mark_stack_top, GC_mark_stack_limit);
                   }
+                  /* if we pushed new items or overflowed stack we need to continue processing */
+                  if (((word)GC_mark_stack_top >= (word)GC_mark_stack) || GC_mark_stack_too_small) {
+                      break;
+                  }
+
+                  GC_mark_state = MS_NONE;
+                  return(TRUE);
                 }
                 break;
             }


### PR DESCRIPTION
Change callback to take/return mark stacks similar to GC_mark_proc. This allows client to call GC_mark_and_push and overflow to be handled.

Remove stateful check of GC_mark_stack_empty_called. Instead always call mark_stack_empty_proc and keep processing as long as stack grows or is overflowed.