### PR TITLE
Update visionOS define for later beta builds.

### DIFF
--- a/include/private/gcconfig.h
+++ b/include/private/gcconfig.h
@@ -1720,7 +1720,7 @@ EXTERN_C_BEGIN
       /* There seems to be some issues with trylock hanging on darwin.  */
       /* This should be looked into some more.                          */
 #     define NO_PTHREAD_TRYLOCK
-#     if (TARGET_OS_IPHONE || TARGET_OS_XROS) && !defined(NO_DYLD_BIND_FULLY_IMAGE)
+#     if (TARGET_OS_IPHONE || TARGET_OS_XR || TARGET_OS_VISION) && !defined(NO_DYLD_BIND_FULLY_IMAGE)
         /* iPhone/iPad simulator */
 #       define NO_DYLD_BIND_FULLY_IMAGE
 #     endif
@@ -2302,7 +2302,7 @@ EXTERN_C_BEGIN
       /* FIXME: There seems to be some issues with trylock hanging on   */
       /* darwin. This should be looked into some more.                  */
 #     define NO_PTHREAD_TRYLOCK
-#     if (TARGET_OS_IPHONE || TARGET_OS_XROS) && !defined(NO_DYLD_BIND_FULLY_IMAGE)
+#     if (TARGET_OS_IPHONE || TARGET_OS_XR || TARGET_OS_VISION) && !defined(NO_DYLD_BIND_FULLY_IMAGE)
 #       define NO_DYLD_BIND_FULLY_IMAGE
 #     endif
 #   endif
@@ -2432,7 +2432,7 @@ EXTERN_C_BEGIN
       /* FIXME: There seems to be some issues with trylock hanging on   */
       /* darwin. This should be looked into some more.                  */
 #     define NO_PTHREAD_TRYLOCK
-#     if (TARGET_OS_IPHONE || TARGET_OS_XROS) && !defined(NO_DYLD_BIND_FULLY_IMAGE)
+#     if (TARGET_OS_IPHONE || TARGET_OS_XR || TARGET_OS_VISION) && !defined(NO_DYLD_BIND_FULLY_IMAGE)
 #       define NO_DYLD_BIND_FULLY_IMAGE
 #     endif
 #   endif
@@ -2671,7 +2671,7 @@ EXTERN_C_BEGIN
       /* There seems to be some issues with trylock hanging on darwin.  */
       /* This should be looked into some more.                          */
 #     define NO_PTHREAD_TRYLOCK
-#     if (TARGET_OS_IPHONE || TARGET_OS_XROS) && !defined(NO_DYLD_BIND_FULLY_IMAGE)
+#     if (TARGET_OS_IPHONE || TARGET_OS_XR || TARGET_OS_VISION) && !defined(NO_DYLD_BIND_FULLY_IMAGE)
         /* iPhone/iPad simulator */
 #       define NO_DYLD_BIND_FULLY_IMAGE
 #     endif


### PR DESCRIPTION
Current steve artifacts use TARGET_OS_XR, not TARGET_OS_XROS. Not sure where the latter came from, but I'm not the only one that used that as per Google and confirmation from others internally on the team.

Later builds of Xcode redefine that to TARGET_OS_VISION so we are pre-emptively adding that in as well.

Tested against current visionOS working PRs and seems to work as well as before.

There will be an il2cpp PR as well once this is merged in and I can pick up the `unity-master` change.

Further research looks like this was working simply because Apple has so far decided that TARGET_OS_IPHONE and TARGET_OS_IOS are defined as well as TARGET_OS_XR/VISION. That would mean that this was all working by accident with the TARGET_OS_XROS.