### PR TITLE
[UUM-53413] Fix & extend GC memory heap reporting

### DIFF
--- a/heapsections.c
+++ b/heapsections.c
@@ -25,15 +25,6 @@ void GC_foreach_heap_section(void* user_data, GC_heap_section_proc callback)
 			sectionEnd = GC_heap_sects[i].hs_start + GC_heap_sects[i].hs_bytes;
 		}
 
-		callback(user_data, sectionStart, sectionEnd);
-
-/*
-		// Intentionally commented out
-		// In the future we might extend to report free/used blocks
-		// but for now we just report entire heap allocation sections, 
-		// to keep compatibility with il2cpp and avoid Memory Profiler 
-		// snapshot format change. 
-
 		while (sectionStart < sectionEnd)
 		{
 			// This does lookup into 2 level tree data structure,
@@ -46,14 +37,14 @@ void GC_foreach_heap_section(void* user_data, GC_heap_section_proc callback)
 				// This pointer has no header registered in headers cache
 				// We skip one HBLKSIZE and attempt to get header for it
 				nextSectionStart = sectionStart + HBLKSIZE;
-				callback(user_data, sectionStart, nextSectionStart, GC_HEAPSECTION_FREE);
+				callback(user_data, sectionStart, nextSectionStart, GC_HEAP_SECTION_TYPE_FREE);
 			}
 			else if (HBLK_IS_FREE(hhdr))
 			{
 				// We have a header, and the block is marked as free
 				// Note: for "free" blocks "hb_sz" = the size in bytes of the whole block.
 				nextSectionStart = sectionStart + hhdr->hb_sz;
-				callback(user_data, sectionStart, nextSectionStart, GC_HEAPSECTION_FREE);
+				callback(user_data, sectionStart, nextSectionStart, GC_HEAP_SECTION_TYPE_FREE);
 			}
 			else
 			{
@@ -61,26 +52,12 @@ void GC_foreach_heap_section(void* user_data, GC_heap_section_proc callback)
 				// Note: for used blocks "hb_sz" = size in bytes, of objects in the block.
 				ptr_t usedSectionEnd = sectionStart + hhdr->hb_sz;
 				nextSectionStart = sectionStart + HBLKSIZE * OBJ_SZ_TO_BLOCKS(hhdr->hb_sz);
-				callback(user_data, sectionStart, usedSectionEnd, GC_HEAPSECTION_USED);
+				callback(user_data, sectionStart, usedSectionEnd, GC_HEAP_SECTION_TYPE_USED);
 				if (nextSectionStart > usedSectionEnd)
-					callback(user_data, usedSectionEnd, nextSectionStart, GC_HEAPSECTION_PADDING);
+					callback(user_data, usedSectionEnd, nextSectionStart, GC_HEAP_SECTION_TYPE_PADDING);
 			}
 
 			sectionStart = nextSectionStart;
 		}
-*/
 	}
-}
-
-void HeapSectionCountIncrementer(void* context, GC_PTR start, GC_PTR end)
-{
-	GC_word* countPtr = (GC_word*)context;
-	(*countPtr)++;
-}
-
-GC_word GC_get_heap_section_count()
-{
-	GC_word count = 0;
-	GC_foreach_heap_section(&count, HeapSectionCountIncrementer);
-	return count;
 }

--- a/heapsections.c
+++ b/heapsections.c
@@ -1,63 +1,24 @@
 #include "private/gc_priv.h"
 
-static struct hblk* GetNextFreeBlock(ptr_t ptr)
-{
-	struct hblk* result = NULL;
-	unsigned i;
-
-	for (i = 0; i < N_HBLK_FLS + 1; i++)
-	{
-		struct hblk* freeBlock = GC_hblkfreelist[i];
-
-		for (freeBlock = GC_hblkfreelist[i]; freeBlock != NULL; freeBlock = HDR(freeBlock)->hb_next)
-		{
-			/* We're only interested in pointers after "ptr" argument */
-			if ((ptr_t)freeBlock < ptr)
-				continue;
-
-			/* If we haven't had a result before or our previous result is */
-			/* ahead of the current freeBlock, mark the current freeBlock as result */
-			if (result == NULL || result > freeBlock)
-				result = freeBlock;
-		}
-	}
-
-	return result;
-}
-
-static void CallHeapSectionCallback(void* user_data, ptr_t start, ptr_t end, GC_heap_section_proc callback)
-{
-	hdr *hhdr = HDR(start);
-
-	// Validate that the heap block is valid, then fire our callback.
-	if (IS_FORWARDING_ADDR_OR_NIL(hhdr) || HBLK_IS_FREE(hhdr)) {
-		return;
-	}
-	
-	callback(user_data, start, end);
-}
-
 void GC_foreach_heap_section(void* user_data, GC_heap_section_proc callback)
 {
-	unsigned i;
-	struct hblk* nextFreeBlock = NULL;
-
 	GC_ASSERT(I_HOLD_LOCK());
 
 	if (callback == NULL)
 		return;
 
-	for (i = 0; i < GC_n_heap_sects; i++)
+	// GC memory is organized in heap sections, which are split in heap blocks.
+	// Each block has header (can get via HDR(ptr)) and it's size is aligned to HBLKSIZE
+	// Block headers are kept separately from memory their points to, and quickly address
+	// headers GC maintains 2-level cache structure which uses address as a hash key.
+	for (unsigned i = 0; i < GC_n_heap_sects; i++)
 	{
 		ptr_t sectionStart = GC_heap_sects[i].hs_start;
 		ptr_t sectionEnd = sectionStart + GC_heap_sects[i].hs_bytes;
        
-		/* Merge in contiguous sections. Copied from GC_dump_regions
-
-		A free block might start in one heap section and extend
-		into the next one. Merging the section avoids crashes when
-		trying to copy the start of section that is a free block
-		continued from the previous section. */
+		// Merge in contiguous sections.
+		// A heap block might start in one heap section and extend 
+		// into the next one. 
 		while (i + 1 < GC_n_heap_sects && GC_heap_sects[i + 1].hs_start == sectionEnd)
 		{
 			++i;
@@ -66,19 +27,29 @@ void GC_foreach_heap_section(void* user_data, GC_heap_section_proc callback)
 
 		while (sectionStart < sectionEnd)
 		{
-			nextFreeBlock = GetNextFreeBlock(sectionStart);
+			// This does lookup into 2 level tree data structure,
+			// which uses address as hash key to find block header.
+			hdr* hhdr = HDR(sectionStart);
 
-			if (nextFreeBlock == NULL || (ptr_t)nextFreeBlock > sectionEnd)
+			if (IS_FORWARDING_ADDR_OR_NIL(hhdr))
 			{
-				CallHeapSectionCallback(user_data, sectionStart, sectionEnd, callback);
-				break;
+				// This pointer has no header registered in headers cache
+				// We skip one HBLKSIZE and attempt to get header for it
+				sectionStart += HBLKSIZE;
+			}
+			else if (HBLK_IS_FREE(hhdr))
+			{
+				// We have a header, and the block is marked as free
+				// Note: for "free" blocks "hb_sz" = the size in bytes of the whole block.
+				sectionStart += hhdr->hb_sz;
 			}
 			else
 			{
-				size_t sectionLength = (char*)nextFreeBlock - sectionStart;
-				if (sectionLength > 0)
-					CallHeapSectionCallback(user_data, sectionStart, sectionStart + sectionLength, callback);
-				sectionStart = (char*)nextFreeBlock + HDR(nextFreeBlock)->hb_sz;
+				// This heap block is used, report it
+				// Note: for used blocks "hb_sz" = size in bytes, of objects in the block.
+				ptr_t nextSectionBlock = sectionStart + HBLKSIZE * OBJ_SZ_TO_BLOCKS(hhdr->hb_sz);
+				callback(user_data, sectionStart, nextSectionBlock);
+				sectionStart = nextSectionBlock;
 			}
 		}
 	}

--- a/include/gc.h
+++ b/include/gc.h
@@ -2046,9 +2046,14 @@ GC_API void GC_CALL GC_set_disable_automatic_collection(int);
 
 /* APIs for getting access to raw GC heap */
 /* These are NOT thread safe, so should be called with GC lock held */
-typedef void (*GC_heap_section_proc)(void* user_data, GC_PTR start, GC_PTR end);
+typedef enum
+{
+	GC_HEAP_SECTION_TYPE_FREE = 0,
+	GC_HEAP_SECTION_TYPE_PADDING = 1,
+	GC_HEAP_SECTION_TYPE_USED = 2
+} GC_heap_section_type;
+typedef void (*GC_heap_section_proc)(void* user_data, GC_PTR start, GC_PTR end, GC_heap_section_type type);
 GC_API void GC_foreach_heap_section(void* user_data, GC_heap_section_proc callback);
-GC_API GC_word GC_get_heap_section_count(void);
 
 #ifdef __cplusplus
   } /* extern "C" */


### PR DESCRIPTION
This PR fixes what is being reported to the Memory Profiler.
Before the PR:
- Only used parts of GC heap were reported

After:
- Report used, free and padding (difference between HBLOCK aligned section and the actual allocation)

This is all needed for:
- a correct reporting of "reserved" memory
- avoid parsing errors when some objects are in free sections (probably objects marked for GC?)