### PR TITLE
Add mark stack query functions

### DIFF
--- a/include/gc.h
+++ b/include/gc.h
@@ -2044,6 +2044,9 @@ GC_API void GC_CALL GC_disable_incremental(void);
 GC_API void GC_CALL GC_start_incremental_collection (void);
 GC_API void GC_CALL GC_set_disable_automatic_collection(int);
 
+GC_API int GC_CALL GC_get_mark_stack_bytes_remaining();
+GC_API int GC_CALL GC_get_mark_stack_initial_size();
+
 /* APIs for getting access to raw GC heap */
 /* These are NOT thread safe, so should be called with GC lock held */
 typedef enum

--- a/misc.c
+++ b/misc.c
@@ -2569,6 +2569,16 @@ GC_API void GC_CALL GC_start_world_external()
     UNLOCK();
 }
 
+GC_API int GC_CALL GC_get_mark_stack_bytes_remaining()
+{
+  return (word)GC_mark_stack_limit - (word)GC_mark_stack_top;
+}
+
+GC_API int GC_CALL GC_get_mark_stack_initial_size()
+{
+  return INITIAL_MARK_STACK_SIZE;
+}
+
 /* Disable incremental GC. Only tested with MANUAL_VDB mode. Might */
 /* require extra teardown work when using other VDB configs.*/
 GC_API void GC_CALL GC_disable_incremental(void)


### PR DESCRIPTION
In order to have better heuristics (or at least diagnostics) for the callbacks we latch to GC_set_push_other_roots, we need to have some idea how full the mark stack is/was.

Add those functions here.