### PR TITLE
Use madvise on Linux instead of mmap to return pages to the OS

### DIFF
--- a/os_dep.c
+++ b/os_dep.c
@@ -2563,13 +2563,27 @@ GC_INNER void GC_unmap(ptr_t start, size_t bytes)
       /* We immediately remap it to prevent an intervening mmap from    */
       /* accidentally grabbing the same address space.                  */
       {
-#       ifdef CYGWIN32
+#       if defined(CYGWIN32) || defined(LINUX)
           /* Calling mmap() with the new protection flags on an         */
           /* existing memory map with MAP_FIXED is broken on Cygwin.    */
           /* However, calling mprotect() on the given address range     */
           /* with PROT_NONE seems to work fine.                         */
-          if (mprotect(start_addr, len, PROT_NONE))
-            ABORT("mprotect(PROT_NONE) failed");
+          /* On Linux, low RLIMIT_AS value may lead to mmap failure.    */
+#         if defined(LINUX) && !defined(FORCE_MPROTECT_BEFORE_MADVISE)
+            /* On Linux, at least, madvise() should be sufficient.      */
+#         else
+            if (mprotect(start_addr, len, PROT_NONE))
+              ABORT("mprotect(PROT_NONE) failed");
+#         endif
+#         if !defined(CYGWIN32)
+            /* On Linux (and some other platforms probably),    */
+            /* mprotect(PROT_NONE) is just disabling access to  */
+            /* the pages but not returning them to OS.          */
+            if (madvise(start_addr, len, MADV_DONTNEED) == -1)
+              ABORT_ARG3("unmap: madvise failed",
+                         " at %p (length %lu), errcode= %d",
+                         (void *)start_addr, (unsigned long)len, errno);
+#         endif
 #       else
           void * result = mmap(start_addr, len, PROT_NONE,
                                MAP_PRIVATE | MAP_FIXED | OPT_MAP_ANON,
@@ -2623,10 +2637,13 @@ GC_INNER void GC_remap(ptr_t start, size_t bytes)
           start_addr += alloc_len;
           len -= alloc_len;
       }
+#     undef IGNORE_PAGES_EXECUTABLE
 #   else
       /* It was already remapped with PROT_NONE. */
       {
-#       ifdef NACL
+#       if !defined(FORCE_MPROTECT_BEFORE_MADVISE) && defined(LINUX) && !defined(PREFER_MMAP_PROT_NONE)
+          /* Nothing to unprotect as madvise() is just a hint.  */
+#       elif defined(NACL)
           /* NaCl does not expose mprotect, but mmap should work fine.  */
           void *result = mmap(start_addr, len, (PROT_READ | PROT_WRITE)
                                     | (GC_pages_executable ? PROT_EXEC : 0),
@@ -2637,6 +2654,7 @@ GC_INNER void GC_remap(ptr_t start, size_t bytes)
 #         if defined(CPPCHECK) || defined(LINT2)
             GC_noop1((word)result);
 #         endif
+#         undef IGNORE_PAGES_EXECUTABLE
 #       else
           if (mprotect(start_addr, len, (PROT_READ | PROT_WRITE)
                             | (GC_pages_executable ? PROT_EXEC : 0)) != 0) {
@@ -2644,9 +2662,9 @@ GC_INNER void GC_remap(ptr_t start, size_t bytes)
                        " at %p (length %lu), errcode= %d",
                        (void *)start_addr, (unsigned long)len, errno);
           }
+#         undef IGNORE_PAGES_EXECUTABLE
 #       endif /* !NACL */
       }
-#     undef IGNORE_PAGES_EXECUTABLE
       GC_unmapped_bytes -= len;
 #   endif
 }
@@ -2688,9 +2706,22 @@ GC_INNER void GC_unmap_gap(ptr_t start1, size_t bytes1, ptr_t start2,
 #   else
       if (len != 0) {
         /* Immediately remap as above. */
-#       ifdef CYGWIN32
-          if (mprotect(start_addr, len, PROT_NONE))
-            ABORT("mprotect(PROT_NONE) failed");
+#       if defined(CYGWIN32) || defined(LINUX)
+#         if defined(LINUX) && !defined(FORCE_MPROTECT_BEFORE_MADVISE)
+            /* On Linux, at least, madvise() should be sufficient.      */
+#         else
+            if (mprotect(start_addr, len, PROT_NONE))
+              ABORT("mprotect(PROT_NONE) failed");
+#         endif
+#         if !defined(CYGWIN32)
+            /* On Linux (and some other platforms probably),    */
+            /* mprotect(PROT_NONE) is just disabling access to  */
+            /* the pages but not returning them to OS.          */
+            if (madvise(start_addr, len, MADV_DONTNEED) == -1)
+              ABORT_ARG3("unmap_gap: madvise failed",
+                         " at %p (length %lu), errcode= %d",
+                         (void *)start_addr, (unsigned long)len, errno);
+#         endif
 #       else
           void * result = mmap(start_addr, len, PROT_NONE,
                                MAP_PRIVATE | MAP_FIXED | OPT_MAP_ANON,

--- a/os_dep.c
+++ b/os_dep.c
@@ -3,6 +3,7 @@
  * Copyright (c) 1991-1995 by Xerox Corporation.  All rights reserved.
  * Copyright (c) 1996-1999 by Silicon Graphics.  All rights reserved.
  * Copyright (c) 1999 by Hewlett-Packard Company.  All rights reserved.
+ * Copyright (c) 2008-2022 Ivan Maidanski
  *
  * THIS MATERIAL IS PROVIDED AS IS, WITH ABSOLUTELY NO WARRANTY EXPRESSED
  * OR IMPLIED.  ANY USE IS AT YOUR OWN RISK.


### PR DESCRIPTION
Cherrypicked fix from Meta that allows boehm to return pages on linux to avoid running out and crashing: https://github.com/Unity-Technologies/bdwgc/commit/2fdb245c59cf5fafb56741daf2b2087ad447e825